### PR TITLE
Updated links to new repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,9 @@ Pull requests welcome! New code should follow the [existing style][style-guide]
 
 To suggest a feature or report a bug: http://github.com/zeekay/ellipsis/issues.
 
+### License
+Ellipsis is open-source software licensed under the [MIT license][mit-license].
+
 [gitter-image]: https://img.shields.io/badge/gitter-join_chat-brightgreen.svg
 [gitter-url]:   https://gitter.im/zeekay/hi
 [travis-image]: https://img.shields.io/travis/zeekay/ellipsis.svg
@@ -444,3 +447,5 @@ To suggest a feature or report a bug: http://github.com/zeekay/ellipsis/issues.
 [style-guide]:  https://google-styleguide.googlecode.com/svn/trunk/shell.xml
 [zeesh]:        https://github.com/zeekay/zeesh
 [zshcomp]:      https://github.com/zeekay/ellipsis/blob/master/comp/_ellipsis
+
+[mit-license]:  http://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ specifiying user or a full repo url. Defaults to `$(git config github.user)` or
 
 #### ELLIPSIS_REPO
 Customize location of ellipsis repo cloned during a curl-based install. Defaults
-to `https://github.com/zeekay/ellipsis`.
+to `https://github.com/ellipsis/ellipsis`.
 
 #### ELLIPSIS_PROTO
 Customizes which protocol new packages are cloned with, you can specify
@@ -430,8 +430,8 @@ Ellipsis is open-source software licensed under the [MIT license][mit-license].
 
 [gitter-image]: https://img.shields.io/badge/gitter-join_chat-brightgreen.svg
 [gitter-url]:   https://gitter.im/zeekay/hi
-[travis-image]: https://img.shields.io/travis/zeekay/ellipsis.svg
-[travis-url]:   https://travis-ci.org/zeekay/ellipsis
+[travis-image]: https://img.shields.io/travis/ellipsis/ellipsis.svg
+[travis-url]:   https://travis-ci.org/ellipsis/ellipsis
 
 [bats]:         https://github.com/sstephenson/bats
 [dot-alfred]:   https://github.com/zeekay/dot-alfred
@@ -443,9 +443,9 @@ Ellipsis is open-source software licensed under the [MIT license][mit-license].
 [dot-vim]:      https://github.com/zeekay/dot-vim
 [dot-xmonad]:   https://github.com/zeekay/dot-xmonad
 [dot-zsh]:      https://github.com/zeekay/dot-zsh
-[installer]:    https://github.com/zeekay/ellipsis/blob/gh-pages/index.html
+[installer]:    https://github.com/ellipsis/ellipsis/blob/gh-pages/index.html
 [style-guide]:  https://google-styleguide.googlecode.com/svn/trunk/shell.xml
 [zeesh]:        https://github.com/zeekay/zeesh
-[zshcomp]:      https://github.com/zeekay/ellipsis/blob/master/comp/_ellipsis
+[zshcomp]:      https://github.com/ellipsis/ellipsis/blob/master/comp/_ellipsis
 
 [mit-license]:  http://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ autoload -U compinit; compinit
 Pull requests welcome! New code should follow the [existing style][style-guide]
 (and ideally include [tests][bats]).
 
-To suggest a feature or report a bug: http://github.com/zeekay/ellipsis/issues.
+Suggest a feature or report a bug? Create an [issue][issues]!
 
 ### License
 Ellipsis is open-source software licensed under the [MIT license][mit-license].
@@ -448,4 +448,5 @@ Ellipsis is open-source software licensed under the [MIT license][mit-license].
 [zeesh]:        https://github.com/zeekay/zeesh
 [zshcomp]:      https://github.com/ellipsis/ellipsis/blob/master/comp/_ellipsis
 
+[issues]:       http://github.com/ellipsis/ellipsis/issues
 [mit-license]:  http://opensource.org/licenses/MIT

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -14,7 +14,7 @@ done
 tmp_dir=$(mktemp -d ${TMPDIR:-tmp}-XXXXXX)
 
 # Clone ellipsis into $tmp_dir.
-git clone --depth 1 git://github.com/zeekay/ellipsis.git $tmp_dir/ellipsis
+git clone --depth 1 git://github.com/ellipsis/ellipsis.git $tmp_dir/ellipsis
 
 # Save reference to specified ELLIPSIS_PATH (if any) otherwise final
 # destination: $HOME/.ellipsis.

--- a/scripts/shim.sh
+++ b/scripts/shim.sh
@@ -18,7 +18,7 @@ for dep in $deps; do
 done
 
 # Download full installer and execute with bash
-curl -sL https://raw.githubusercontent.com/zeekay/ellipsis/master/scripts/install.bash > install-$$.bash
+curl -sL https://raw.githubusercontent.com/ellipsis/ellipsis/master/scripts/install.bash > install-$$.bash
 bash install-$$.bash
 
 # Clean up


### PR DESCRIPTION
Updated all links to the new repository location. Before pulling this in, travis-ci should be activated for Ellipsis/ellipsis (will give build:invalid if not activated).

I also added a small part about the license to the readme. 