### PR TITLE
Fixed git.clone issue when using single argument

### DIFF
--- a/src/git.bash
+++ b/src/git.bash
@@ -10,7 +10,7 @@ load pkg
 # Clone a Git repo.
 git.clone() {
     if [ -z "$3" ]; then
-        git clone --depth 1 "$1" "$2"
+        git clone --depth 1 "$@"
     else
         git clone --depth 1 "$1" "$2" --branch "$3"
     fi


### PR DESCRIPTION
If `git.clone` was used with a single argument an empty string was appended to the `git clone` command, which resulted in an error.