### PR TITLE
Fix git.clone problem when testing

### DIFF
--- a/src/git.bash
+++ b/src/git.bash
@@ -9,8 +9,10 @@ load pkg
 
 # Clone a Git repo.
 git.clone() {
-    if [ -z "$3" ]; then
-        git clone --depth 1 "$@"
+    if [ -z "$2" ]; then
+        git clone --depth 1 "$1"
+    elif [ -z "$3" ]; then
+        git clone --depth 1 "$1" "$2"
     else
         git clone --depth 1 "$1" "$2" --branch "$3"
     fi


### PR DESCRIPTION
Still don't get why it broke, it was exactly the same before the branch install update. (I've ran test locally first this time)