### PR TITLE
Fixed double call to link hook

### DIFF
--- a/src/hooks.bash
+++ b/src/hooks.bash
@@ -48,9 +48,9 @@ hooks.link() {
     fs.link_files $PKG_PATH
 }
 
-# Symlink files in PKG_PATH into ELLIPSIS_HOME.
+# Dummy, by default only symlinks are made.
 hooks.install() {
-    pkg.run_hook "link"
+    :
 }
 
 # Remove package's symlinks in ELLIPSIS_HOME.


### PR DESCRIPTION
In `ellipsis.install` the link and install hooks are called. This makes it
unnecessary to call the link hook again in the install hook.

By removing the call from the install hook, the user can override
the hook without having to call the link hook manually.