### PR TITLE
Allow short-hand notation for ellipsis extensions

### DIFF
--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -67,6 +67,11 @@ ellipsis.install() {
                     PKG_NAME="$(pkg.name_from_shorthand $PKG_RAW)"
                     PKG_URL="$ELLIPSIS_PROTO://github.com/$PKG_USER/dot-$(pkg.name_stripped $PKG_NAME)"
                 ;;
+                # Easy extension installation
+                ellipsis-*)
+                    PKG_NAME="$PKG_RAW"
+                    PKG_URL="$ELLIPSIS_PROTO://github.com/ellipsis/$PKG_NAME"
+                ;;
                 *)
                     PKG_NAME="$PKG_RAW"
                     PKG_URL="$ELLIPSIS_PROTO://github.com/$ELLIPSIS_USER/dot-$(pkg.name_stripped $PKG_NAME)"


### PR DESCRIPTION
Makes installing "official" extensions a lot easier.

It does make it impossible to install a package named `dot-ellipsis-package` with just `ellipsis-package` but I don't think anyone want's to do that. (and `username/ellipsis-package` still works as expected)