### PR TITLE
Msg and log functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Variable                        | Description
 `ELLIPSIS_HOME`                 | Customize which folder files are symlinked into, defaults to `$HOME`. (Mostly useful for testing)
 `ELLIPSIS_PATH`                 | Customize where ellipsis lives on your filesystem, defaults to `~/.ellipsis`.
 `ELLIPSIS_PACKAGE`              | Customize where ellipsis installs packages on your filesystem, defaults to `~/.ellipsis/packages`.
+`ELLIPSIS_LOGFILE`              | Customize location of the logfile
 
 ```bash
 export ELLIPSIS_USER="zeekay"

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -6,6 +6,7 @@ load fs
 load git
 load pkg
 load utils
+load log
 
 # List all installed packages.
 ellipsis.list_packages() {
@@ -33,7 +34,7 @@ ellipsis.each() {
 # defined, all files are symlinked into ELLIPSIS_HOME using `fs.link_files`.
 ellipsis.install() {
     if [ $# -lt 1 ]; then
-        log.error "No package specified for install"
+        log.fail "No package specified for install"
         exit 1
     fi
 
@@ -100,7 +101,7 @@ ellipsis.install() {
 # defined, all symlinked files in ELLIPSIS_HOME are removed and package is rm -rf'd.
 ellipsis.uninstall() {
     if [ $# -ne 1 ]; then
-        log.error "No package specified for uninstall"
+        log.fail "No package specified for uninstall"
         exit 1
     fi
 
@@ -112,7 +113,7 @@ ellipsis.uninstall() {
 # Re-link unlinked packages.
 ellipsis.link() {
     if [ $# -ne 1 ]; then
-        log.error "No package specified to link"
+        log.fail "No package specified to link"
         exit 1
     fi
 
@@ -125,7 +126,7 @@ ellipsis.link() {
 # hook is defined, all symlinked files in ELLIPSIS_HOME are removed.
 ellipsis.unlink() {
     if [ $# -ne 1 ]; then
-        log.error "No package specified to unlink"
+        log.fail "No package specified to unlink"
         exit 1
     fi
 
@@ -316,7 +317,7 @@ ellipsis.clean() {
 # Re-link unlinked packages.
 ellipsis.add() {
     if [ $# -lt 2 ]; then
-        log.error "Usage: ellipsis add <package> <dotfile>"
+        log.fail "Usage: ellipsis add <package> <dotfile>"
         exit 1
     fi
 

--- a/src/fs.bash
+++ b/src/fs.bash
@@ -2,7 +2,7 @@
 #
 # Files/path functions used by ellipis.
 
-load log
+load msg
 load path
 
 # return true if folder is empty
@@ -69,7 +69,7 @@ fs.backup() {
 
     # remove broken symlink
     if fs.is_broken_symlink "$original"; then
-        log.dim "rm ~/$name (broken link to $(readlink $original))"
+        msg.dim "rm ~/$name (broken link to $(readlink $original))"
         rm $original
         return
     fi
@@ -81,7 +81,7 @@ fs.backup() {
 
     # if file exists and is a symlink to ellipsis, remove
     if fs.is_ellipsis_symlink "$original"; then
-        log.dim "rm ~/$name (linked to $(path.relative_to_packages $(readlink $original)))"
+        msg.dim "rm ~/$name (linked to $(path.relative_to_packages $(readlink $original)))"
         rm "$original"
         return
     fi

--- a/src/hooks.bash
+++ b/src/hooks.bash
@@ -8,6 +8,7 @@ load os
 load path
 load pkg
 load utils
+load log
 
 # List of hooks available to package authors.
 PKG_HOOKS=(
@@ -28,12 +29,12 @@ hooks.add() {
     local dst="$PKG_PATH/$(path.strip_dot $(basename "$1"))"
 
     if fs.file_exists "$dst"; then
-        log.error "$dst already exists!"
+        log.fail "$dst already exists!"
         exit 1
     fi
 
     if ! fs.file_exists "$1"; then
-        log.error "$1 does not exist!"
+        log.fail "$1 does not exist!"
         exit 1
     fi
 

--- a/src/log.bash
+++ b/src/log.bash
@@ -2,18 +2,43 @@
 #
 # Logging utilities.
 
+load msg
+
+# Print log message and store to logfile
+log.store() {
+    msg.print "$@"
+
+    local msg="$(msg.log "$@")"
+    local timestamp="$(date +"%y/%m/%d %H:%M:%S")"
+    echo "$timestamp: $msg" >> ${ELLIPSIS_LOGFILE:-"/tmp/ellipsis.log"}
+}
+
+# Log success
+log.ok() {
+    log.store "[\033[32m ok \033[0m] $@"
+}
+
+# Log info
 log.info() {
-    echo -e "\033[33minfo\033[0m" "$@"
+    log.store "[\033[36minfo\033[0m] $@"
 }
 
-log.error() {
-    echo -e "\033[31merror\033[0m" "$@"
-}
-
+# Log warning
 log.warn() {
-    echo -e "\033[33mwarn\033[0m" "$@"
+    log.store "[\033[33mwarn\033[0m] $@"
 }
 
+# Log error
+log.error() {
+    log.store "[\033[31m err\033[0m] $@"
+}
+
+# Log failure
+log.fail() {
+    log.store "[\033[31mFAIL\033[0m] $@"
+}
+
+# Deprecated; use msg.dim
 log.dim() {
-    echo -e "\033[90m$@\033[0m"
+    msg.dim "$@"
 }

--- a/src/msg.bash
+++ b/src/msg.bash
@@ -1,0 +1,29 @@
+# msg.bash
+#
+# Functions to show messages to the user
+
+load utils
+
+# Show message
+msg.print() {
+    if [ -t 1 ] || [ -n "$ELLIPSIS_FORCE_COLOR" ]; then
+        echo -e "$@"
+    else
+        msg.log "$@"
+    fi
+}
+
+# Show message without colors
+msg.log() {
+    utils.strip_colors "$(echo -e "$@")"
+}
+
+# Show bold message
+msg.bold() {
+    msg.print "\033[1m$@\033[0m"
+}
+
+# Show dim message
+msg.dim() {
+    msg.print "\033[90m$@\033[0m"
+}

--- a/src/pkg.bash
+++ b/src/pkg.bash
@@ -63,7 +63,7 @@ pkg.init() {
 
     # Exit if we're asked to operate on an unknown package.
     if [ ! -d "$PKG_PATH" ]; then
-        log.error "Unkown package $PKG_NAME, $(path.relative_to_home $PKG_PATH) missing!"
+        log.fail "Unkown package $PKG_NAME, $(path.relative_to_home $PKG_PATH) missing!"
         exit 1
     fi
 
@@ -111,7 +111,7 @@ pkg.run() {
 pkg.run_hook() {
     # Prevent unknown hooks from running
     if ! utils.cmd_exists hooks.$1; then
-        log.error "Unknown hook!"
+        log.fail "Unknown hook!"
         exit 1
     fi
 

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -7,6 +7,7 @@ load utils
 setup() {
     export ELLIPSIS_HOME=$TESTS_DIR/tmp/ellipsis_home
     export ELLIPSIS_PACKAGES=$ELLIPSIS_HOME/.ellipsis/packages
+    export ELLIPSIS_LOGFILE=$TESTS_DIR/tmp/log
     mkdir -p $ELLIPSIS_PACKAGES
     echo 'old' > $ELLIPSIS_HOME/.file
 

--- a/test/fs.bats
+++ b/test/fs.bats
@@ -7,6 +7,7 @@ setup() {
     mkdir -p tmp/ellipsis_home/.ellipsis
     export ELLIPSIS_HOME=tmp/ellipsis_home
     export ELLIPSIS_PATH=$ELLIPSIS_HOME/.ellipsis
+    export ELLIPSIS_LOGFILE=tmp/log
     touch tmp/file_to_backup
     touch tmp/file_to_link
     ln -s file_to_backup tmp/symlink

--- a/test/log.bats
+++ b/test/log.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load _helper
+load log
+
+setup() {
+    mkdir -p tmp
+    export ELLIPSIS_LOGFILE=tmp/log
+}
+
+teardown() {
+    rm -rf tmp
+}
+
+in_log() {
+    local msg=$1
+    local regex="([0-9]{1,2}/){2}[0-9]{1,2} ([0-9]{1,2}:){3} $msg"
+
+    grep -E "$regex" "$ELLIPSIS_LOGFILE" >/dev/null 2>&1
+    echo "$?"
+}
+
+@test "log.store stores messages to logfile" {
+    run log.store "Test file logging"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Test file logging" ]
+    [ "$(in_log "Test file logging")" -eq 0 ]
+}
+
+@test "log.ok logs success" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.ok "Test success message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[[32m ok [0m] Test success message" ]
+}
+
+@test "log.ok logs success colorless (non interactive)" {
+    run log.ok "Test success message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[ ok ] Test success message" ]
+}
+
+@test "log.info logs info" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.info "Test info message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[[36minfo[0m] Test info message" ]
+}
+
+@test "log.info logs info colorless (non interactive)" {
+    run log.info "Test info message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[info] Test info message" ]
+}
+
+@test "log.warn logs warning" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.warn "Test warning message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[[33mwarn[0m] Test warning message" ]
+}
+
+@test "log.warn logs warning colorless (non interactive)" {
+    run log.warn "Test warning message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[warn] Test warning message" ]
+}
+
+@test "log.error logs error" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.error "Test error message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[[31m err[0m] Test error message" ]
+}
+
+@test "log.error logs error colorless (non interactive)" {
+    run log.error "Test error message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[ err] Test error message" ]
+}
+
+@test "log.fail logs failure" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.fail "Test fail message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[[31mFAIL[0m] Test fail message" ]
+}
+
+@test "log.fail logs failure colorless (non interactive)" {
+    run log.fail "Test fail message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[FAIL] Test fail message" ]
+}
+
+@test "log.dim shows dimmed message" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.dim "Test dim message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[90mTest dim message[0m" ]
+}
+
+@test "log.dim shows dimmed message colorless (non interactive)" {
+    run log.dim "Test dim message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Test dim message" ]
+}

--- a/test/msg.bats
+++ b/test/msg.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load _helper
+load msg
+
+@test "msg.print shows message" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run msg.print "\033[1mTest print message\033[0m"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[1mTest print message[0m" ]
+}
+
+@test "msg.print shows message colorless (non interactive)" {
+    run msg.print "\033[1mTest print message (colored)\033[0m"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Test print message (colored)" ]
+}
+
+@test "msg.log shows message without colors" {
+    run msg.log "\033[1mTest no color message\033[0m"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Test no color message" ]
+}
+
+@test "msg.bold shows bold message" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run msg.bold "Test bold message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[1mTest bold message[0m" ]
+}
+
+@test "msg.bold shows bold message colorless (non interactive)" {
+    run msg.bold "Test bold message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Test bold message" ]
+}
+
+@test "msg.dim shows dim message" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run msg.dim "Test dim message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "[90mTest dim message[0m" ]
+}
+
+@test "msg.dim shows dim message colorless (non interactive)" {
+    run msg.dim "Test dim message"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "Test dim message" ]
+}

--- a/test/pkg.bats
+++ b/test/pkg.bats
@@ -6,6 +6,7 @@ load pkg
 setup() {
     mkdir -p tmp/ellipsis_home
     export ELLIPSIS_HOME=tmp/ellipsis_home
+    export ELLIPSIS_LOGFILE=tmp/log
 }
 
 teardown() {


### PR DESCRIPTION
Adds messaging functions used to show messages to the user and updates the log functions.

For Ellipsis-TPM I needed functions that could be overwritten to show all messages in Tmux copy mode. The `msg` functions do just that. They also make it possible to have more control over the output and make it possible to test colored and non colored output.

As the message functions show messages I updated the log functions to also log info to a file. I also added `log.fail` to make a distinction between an error that stops normal execution (fail) and an error that allows further actions (error).

In Ellipsis-TPM all actions that change something are logged. If everything goes well and nothing is altered a normal message is displayed. This makes it possible to keep track of changes over time with the log file. (Only important warnings/info is also logged)  Maybe a good idea to use the same log/message policy in Ellipsis?