### PR TITLE
Fixed utils.run_installer when a URL is passed as $1

### DIFF
--- a/src/utils.bash
+++ b/src/utils.bash
@@ -22,6 +22,7 @@ utils.prompt() {
 
 # Run web-based installers
 utils.run_installer() {
+    local url="${url:-$1}"
     # save reference to current dir
     local cwd=$(pwd)
     # create temp dir and cd to it


### PR DESCRIPTION
The function uses `$url` but if the URL is provided as first argument it was never assigned to this variable.