### PR TITLE
Make sure tests don't pollute local logs

### DIFF
--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -7,5 +7,7 @@ export TESTS_DIR="$BATS_TEST_DIRNAME"
 export ELLIPSIS_PATH="$(cd "$TESTS_DIR/.." && pwd)"
 export PATH="$ELLIPSIS_PATH/bin:$PATH"
 
+export ELLIPSIS_LOGFILE="/dev/null"
+
 # Initialize ellipsis, which replaces bat's `load` function with ours.
 load ../src/init

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -7,7 +7,6 @@ load utils
 setup() {
     export ELLIPSIS_HOME="$TESTS_DIR/tmp/ellipsis_home"
     export ELLIPSIS_PACKAGES="$ELLIPSIS_HOME/.ellipsis/packages"
-    export ELLIPSIS_LOGFILE="$TESTS_DIR/tmp/log"
     mkdir -p "$ELLIPSIS_PACKAGES"
     echo 'old' > "$ELLIPSIS_HOME/.file"
 

--- a/test/fs.bats
+++ b/test/fs.bats
@@ -7,7 +7,6 @@ setup() {
     mkdir -p tmp/ellipsis_home/.ellipsis
     export ELLIPSIS_HOME=tmp/ellipsis_home
     export ELLIPSIS_PATH=$ELLIPSIS_HOME/.ellipsis
-    export ELLIPSIS_LOGFILE=tmp/log
     touch tmp/file_to_backup
     touch tmp/file_to_link
     ln -s file_to_backup tmp/symlink

--- a/test/pkg.bats
+++ b/test/pkg.bats
@@ -6,7 +6,6 @@ load pkg
 setup() {
     mkdir -p tmp/ellipsis_home
     export ELLIPSIS_HOME=tmp/ellipsis_home
-    export ELLIPSIS_LOGFILE=tmp/log
 }
 
 teardown() {


### PR DESCRIPTION
I disabled logging to the local logfile for all tests on the `_helper` level, so we don't accidentally pollute the local logfile in the future.