### PR TITLE
Remove global color stripping

### DIFF
--- a/bin/ellipsis
+++ b/bin/ellipsis
@@ -22,12 +22,4 @@ source "$ELLIPSIS_PATH/src/init.bash"
 
 load cli
 
-# check for controlling terminal
-if [ -t 1 ]; then
-    cli.run $@
-    exit $?
-else
-    # strip ansi colors
-    cli.run $@ | sed -e 's/\[[^m]*m//g'
-    exit $PIPESTATUS # exit with result of first command in pipe, i.e., cli.run
-fi
+cli.run "$@"

--- a/src/cli.bash
+++ b/src/cli.bash
@@ -44,7 +44,7 @@ cli.version() {
     cd "$ELLIPSIS_PATH"
 
     local sha1="$(git.sha1)"
-    echo -e "\033[1mv$ELLIPSIS_VERSION\033[0m ($sha1)"
+    msg.print "\033[1mv$ELLIPSIS_VERSION\033[0m ($sha1)"
 
     cd "$cwd"
 }


### PR DESCRIPTION
Since the introduction of the messaging functions it is no longer
necessary to strip color codes globally.