### PR TITLE
Init extension support

### DIFF
--- a/bin/ellipsis
+++ b/bin/ellipsis
@@ -16,9 +16,12 @@ do
     fi
 done
 
+# Set path variables used by loader
 ELLIPSIS_PATH="${ELLIPSIS_PATH:-$(cd "$(dirname "$ELLIPSIS_BIN")/.." && pwd)}"
+ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 
-source "$ELLIPSIS_PATH/src/init.bash"
+# Include the load function
+source "$ELLIPSIS_SRC/init.bash"
 
 load cli
 

--- a/src/init.bash
+++ b/src/init.bash
@@ -33,7 +33,12 @@ load() {
         # Mark this module as loaded, prevent infinite recursion, ya know...
         eval "$loaded=1"
 
-        source "$ELLIPSIS_PATH/src/$1.bash"
+        # Load extension specific sources if possible
+        if [ -n "$ELLIPSIS_XSRC" -a -f "$ELLIPSIS_XSRC/$1.bash" ]; then
+            source "$ELLIPSIS_XSRC/$1.bash"
+        else
+            source "$ELLIPSIS_SRC/$1.bash"
+        fi
     fi
 }
 

--- a/src/init.bash
+++ b/src/init.bash
@@ -5,8 +5,8 @@
 
 if [[ -z "$ELLIPSIS_USER" ]]; then
     # Pipe to cat to squash git config's exit code 1 in case of missing key.
-    GITHUB_USER=$(git config github.user | cat)
-    ELLIPSIS_USER=${GITHUB_USER:-zeekay}
+    GITHUB_USER="$(git config github.user | cat)"
+    ELLIPSIS_USER="${GITHUB_USER:-zeekay}"
 fi
 
 # Repostitory defaults.
@@ -18,8 +18,8 @@ ELLIPSIS_HOME="${ELLIPSIS_HOME:-$HOME}"
 ELLIPSIS_PACKAGES="${ELLIPSIS_PACKAGES:-$ELLIPSIS_PATH/packages}"
 
 # Ellipsis is the default package.
-PKG_PATH=${PKG_PATH:-$ELLIPSIS_PATH}
-PKG_NAME=${PKG_NAME:-${PKG_PATH##*/.}}
+PKG_PATH="${PKG_PATH:-$ELLIPSIS_PATH}"
+PKG_NAME="${PKG_NAME:-${PKG_PATH##*/.}}"
 
 # Utility to load other modules. Uses a tiny bit of black magic to ensure each
 # module is only loaded once.

--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -5,6 +5,7 @@
 
 export TESTS_DIR="$BATS_TEST_DIRNAME"
 export ELLIPSIS_PATH="$(cd "$TESTS_DIR/.." && pwd)"
+export ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 export PATH="$ELLIPSIS_PATH/bin:$PATH"
 
 export ELLIPSIS_LOGFILE="/dev/null"


### PR DESCRIPTION
Updates the load function to load files provided by an extension if possible, else loads the Ellipsis version. This makes it possible to use the ellipsis init for extensions to.

Also adds the `ELLIPSIS_SRC` variable which contains the path to the Ellipsis src dir.

(and I also added some missing quotes)

