### PR TITLE
Change install hook order

### DIFF
--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -91,8 +91,8 @@ ellipsis.install() {
         fi
 
         pkg.init "$PKG_PATH"
-        pkg.run_hook "link"
         pkg.run_hook "install"
+        pkg.run_hook "link"
         pkg.del
     done
 }


### PR DESCRIPTION
When installing a package, it would be more logical to call the `link` hook from the `install` hook. This is the case in the `uninstall` hook which calls the `unlink` hook.

It would be nice to have this consistent, but changing it now would brake a lot of `ellipsis.sh` files.

It is however preferred to call the `install` hook before the `link` hook. This should not cause trouble because linking and unlinking already works after installing a package.

The benefit of this change would be that we could compile/build files that would later be linked/unlinked. 