### PR TITLE
Log and msg improvements

### DIFF
--- a/src/init.bash
+++ b/src/init.bash
@@ -3,6 +3,13 @@
 # Setup initial globals and load function used to source other modules. This
 # file must be sourced before any others.
 
+# Count nested runs for msg indentation
+if [ -z "$ELLIPSIS_LVL" ]; then
+    export ELLIPSIS_LVL=1
+else
+    let ELLIPSIS_LVL=ELLIPSIS_LVL+1
+fi
+
 if [[ -z "$ELLIPSIS_USER" ]]; then
     # Pipe to cat to squash git config's exit code 1 in case of missing key.
     GITHUB_USER="$(git config github.user | cat)"

--- a/src/log.bash
+++ b/src/log.bash
@@ -6,36 +6,45 @@ load msg
 
 # Print log message and store to logfile
 log.store() {
-    msg.print "$@"
-
-    local msg="$(msg.log "$@")"
+    local err_type="$1"
+    local msg="${@:2}"
     local timestamp="$(date +"%y/%m/%d %H:%M:%S")"
-    echo "$timestamp: $msg" >> ${ELLIPSIS_LOGFILE:-"/tmp/ellipsis.log"}
+
+    # Also ouput message to terminal
+    msg.print "$err_type $msg"
+
+    # Prepend extension name to message if needed
+    if [ -n "$ELLIPSIS_XNAME" ]; then
+        msg="$ELLIPSIS_XNAME : $msg"
+    fi
+
+    # Write to log
+    msg.log "$timestamp: $err_type $msg" >> ${ELLIPSIS_LOGFILE:-"/tmp/ellipsis.log"}
 }
 
 # Log success
 log.ok() {
-    log.store "[\033[32m ok \033[0m] $@"
+    log.store "[\033[32m ok \033[0m]" "$@"
 }
 
 # Log info
 log.info() {
-    log.store "[\033[36minfo\033[0m] $@"
+    log.store "[\033[36minfo\033[0m]" "$@"
 }
 
 # Log warning
 log.warn() {
-    log.store "[\033[33mwarn\033[0m] $@"
+    log.store "[\033[33mwarn\033[0m]" "$@"
 }
 
 # Log error
 log.error() {
-    log.store "[\033[31m err\033[0m] $@"
+    log.store "[\033[31m err\033[0m]" "$@"
 }
 
 # Log failure
 log.fail() {
-    log.store "[\033[31mFAIL\033[0m] $@"
+    log.store "[\033[31mFAIL\033[0m]" "$@"
 }
 
 # Deprecated; use msg.dim

--- a/src/msg.bash
+++ b/src/msg.bash
@@ -7,9 +7,9 @@ load utils
 # Show message
 msg.print() {
     if [ -t 1 ] || [ -n "$ELLIPSIS_FORCE_COLOR" ]; then
-        echo -e "$@"
+        echo -e "$(msg.tabs)$@"
     else
-        msg.log "$@"
+        msg.log "$(msg.tabs)$@"
     fi
 }
 
@@ -26,4 +26,10 @@ msg.bold() {
 # Show dim message
 msg.dim() {
     msg.print "\033[90m$@\033[0m"
+}
+
+msg.tabs() {
+    for (( n=1; n<"$ELLIPSIS_LVL"; n++ )); do
+        printf '    '
+    done
 }

--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -3,12 +3,17 @@
 # test/_helper.bash
 # Just a little helper file for bats.
 
+# Set path vars
 export TESTS_DIR="$BATS_TEST_DIRNAME"
 export ELLIPSIS_PATH="$(cd "$TESTS_DIR/.." && pwd)"
 export ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 export PATH="$ELLIPSIS_PATH/bin:$PATH"
 
+# Don't log tests
 export ELLIPSIS_LOGFILE="/dev/null"
+
+# Reset nesting level
+export ELLIPSIS_LVL=0
 
 # Initialize ellipsis, which replaces bat's `load` function with ours.
 load ../src/init

--- a/test/bin.bats
+++ b/test/bin.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+#
+# Checks if bin/ellipsis does all it needs to do.
+
+setup() {
+    export TESTS_DIR="$BATS_TEST_DIRNAME"
+    export _ELLIPSIS_PATH="$(cd "$TESTS_DIR/.." && pwd)"
+    export PATH="$_ELLIPSIS_PATH/bin:$PATH"
+    mkdir -p "$TESTS_DIR/tmp"
+    ln -s "$_ELLIPSIS_PATH/bin/ellipsis" "$TESTS_DIR/tmp/l1"
+    ln -s "$TESTS_DIR/tmp/l1" "$TESTS_DIR/tmp/l2"
+    ln -s "$TESTS_DIR/tmp/l2" "$TESTS_DIR/tmp/l3"
+    ln -s "$TESTS_DIR/tmp/l3" "$TESTS_DIR/tmp/l4"
+    ln -s "$TESTS_DIR/tmp/l4" "$TESTS_DIR/tmp/ellipsis"
+}
+
+teardown() {
+    rm -rf "$TESTS_DIR/tmp"
+}
+
+@test "ellipsis <command> calls cli.run <command>" {
+  run ellipsis version
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : "v[0-9][0-9.]*") -ne 0 ]
+}
+
+@test "ellipsis can find its location trough multiple symlinks" {
+  run "$TESTS_DIR/tmp/ellipsis" version
+  [ "$status" -eq 0 ]
+}

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -1,27 +1,28 @@
 #!/usr/bin/env bats
 
 load _helper
+load cli
 
 @test "cli.run without command prints usage" {
-  run ellipsis
+  run cli.run
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Usage: ellipsis <command>" ]
 }
 
 @test "cli.run with invalid command prints usage" {
-  run ellipsis invalid_command
+  run cli.run invalid_command
   [ "$status" -eq 1 ]
   [ "${lines[1]}" = "Usage: ellipsis <command>" ]
 }
 
 @test "cli.run --help prints usage" {
-  run ellipsis --help
+  run cli.run --help
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "Usage: ellipsis <command>" ]
 }
 
 @test "cli.run --version prints version" {
-  run ellipsis --version
+  run cli.run --version
   [ "$status" -eq 0 ]
   [ $(expr "$output" : "v[0-9][0-9.]*") -ne 0 ]
 }

--- a/test/log.bats
+++ b/test/log.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 in_log() {
-    local msg=$1
+    local msg="$1"
     local regex="([0-9]{1,2}/){2}[0-9]{1,2} ([0-9]{1,2}:){3} $msg"
 
     grep -E "$regex" "$ELLIPSIS_LOGFILE" >/dev/null 2>&1
@@ -21,86 +21,102 @@ in_log() {
 }
 
 @test "log.store stores messages to logfile" {
-    run log.store "Test file logging"
+    run log.store "err_type" "Test file logging"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "Test file logging" ]
-    [ "$(in_log "Test file logging")" -eq 0 ]
+    [ "$output" = "err_type Test file logging" ]
+    [ "$(in_log "err_type Test file logging")" -eq 0 ]
+}
+
+@test "log.store stores messages colorless" {
+    ELLIPSIS_FORCE_COLOR=1\
+    run log.store "\033[32m ok \033[0m" "Test file logging"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[32m ok [0m Test file logging" ]
+    [ "$(in_log " ok  Test file logging")" -eq 0 ]
+}
+
+@test "log.store stores messages with extension prefix when needed" {
+    ELLIPSIS_XNAME="Test"\
+    run log.store "err_type" "Test file logging"
+    [ "$status" -eq 0 ]
+    [ "$output" = "err_type Test file logging" ]
+    [ "$(in_log "err_type Test : Test file logging")" -eq 0 ]
 }
 
 @test "log.ok logs success" {
     ELLIPSIS_FORCE_COLOR=1\
     run log.ok "Test success message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[[32m ok [0m] Test success message" ]
+    [ "$output" = "[[32m ok [0m] Test success message" ]
 }
 
 @test "log.ok logs success colorless (non interactive)" {
     run log.ok "Test success message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[ ok ] Test success message" ]
+    [ "$output" = "[ ok ] Test success message" ]
 }
 
 @test "log.info logs info" {
     ELLIPSIS_FORCE_COLOR=1\
     run log.info "Test info message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[[36minfo[0m] Test info message" ]
+    [ "$output" = "[[36minfo[0m] Test info message" ]
 }
 
 @test "log.info logs info colorless (non interactive)" {
     run log.info "Test info message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[info] Test info message" ]
+    [ "$output" = "[info] Test info message" ]
 }
 
 @test "log.warn logs warning" {
     ELLIPSIS_FORCE_COLOR=1\
     run log.warn "Test warning message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[[33mwarn[0m] Test warning message" ]
+    [ "$output" = "[[33mwarn[0m] Test warning message" ]
 }
 
 @test "log.warn logs warning colorless (non interactive)" {
     run log.warn "Test warning message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[warn] Test warning message" ]
+    [ "$output" = "[warn] Test warning message" ]
 }
 
 @test "log.error logs error" {
     ELLIPSIS_FORCE_COLOR=1\
     run log.error "Test error message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[[31m err[0m] Test error message" ]
+    [ "$output" = "[[31m err[0m] Test error message" ]
 }
 
 @test "log.error logs error colorless (non interactive)" {
     run log.error "Test error message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[ err] Test error message" ]
+    [ "$output" = "[ err] Test error message" ]
 }
 
 @test "log.fail logs failure" {
     ELLIPSIS_FORCE_COLOR=1\
     run log.fail "Test fail message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[[31mFAIL[0m] Test fail message" ]
+    [ "$output" = "[[31mFAIL[0m] Test fail message" ]
 }
 
 @test "log.fail logs failure colorless (non interactive)" {
     run log.fail "Test fail message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[FAIL] Test fail message" ]
+    [ "$output" = "[FAIL] Test fail message" ]
 }
 
 @test "log.dim shows dimmed message" {
     ELLIPSIS_FORCE_COLOR=1\
     run log.dim "Test dim message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "[90mTest dim message[0m" ]
+    [ "$output" = "[90mTest dim message[0m" ]
 }
 
 @test "log.dim shows dimmed message colorless (non interactive)" {
     run log.dim "Test dim message"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "Test dim message" ]
+    [ "$output" = "Test dim message" ]
 }

--- a/test/msg.bats
+++ b/test/msg.bats
@@ -16,6 +16,19 @@ load msg
     [ "${lines[0]}" = "Test print message (colored)" ]
 }
 
+@test "msg.print shows message indented (nested)" {
+    # 1 level, 4 spaces
+    ELLIPSIS_LVL=2\
+    run msg.print "Test print message indented"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "    Test print message indented" ]
+    # 2 levels, 8 spaces
+    ELLIPSIS_LVL=3\
+    run msg.print "Test print message indented"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "        Test print message indented" ]
+}
+
 @test "msg.log shows message without colors" {
     run msg.log "\033[1mTest no color message\033[0m"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
#### msg
I updated the `msg` function to indent output based on nested runs. This functionality is meant to make output more clear when ellipsis or an ellipsis extension is used inside one of the hooks.

For example, in my tmux package the `update` hook runs `ellipsis-tpm update`. Without this indentation it is hard to see the difference between the output of ellipsis and ellipsis-tpm. I also run `ellipsis install ellipsis-tpm` from my install hook if ellipsis-tpm is not installed.

To keep the tests happy I had to split testing of the `cli` functions and `bin/ellipsis`. The `cli.bats` tests now run the `cli` functions directly and I added a separate `bin.bats` file for testing `bin/ellipsis`. This new test file also tests if symlinks are removed properly when finding `$ELLIPSIS_PATH`.

#### log
Adds extension support. If `$ELLIPSIS_XNAME` is defined it is prepended to log entries. This makes it clear that a certain log message came from an extension. (tests included)