### PR TITLE
Update installer

### DIFF
--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -7,25 +7,25 @@
 deps=(bash curl git)
 
 for dep in ${deps[*]}; do
-    hash $dep 2>/dev/null || { echo >&2 "ellipsis requires $dep to be installed."; exit 1; }
+    hash "$dep" 2>/dev/null || { echo >&2 "ellipsis requires $dep to be installed."; exit 1; }
 done
 
 # Create temp dir.
-tmp_dir=$(mktemp -d ${TMPDIR:-tmp}-XXXXXX)
+tmp_dir="$(mktemp -d "${TMPDIR:-tmp}"-XXXXXX)"
 
 # Clone ellipsis into $tmp_dir.
-git clone --depth 1 git://github.com/ellipsis/ellipsis.git $tmp_dir/ellipsis
+git clone --depth 1 git://github.com/ellipsis/ellipsis.git "$tmp_dir/ellipsis"
 
 # Save reference to specified ELLIPSIS_PATH (if any) otherwise final
 # destination: $HOME/.ellipsis.
-FINAL_ELLIPSIS_PATH=${ELLIPSIS_PATH:-$HOME/.ellipsis}
+FINAL_ELLIPSIS_PATH="${ELLIPSIS_PATH:-$HOME/.ellipsis}"
 
 # Temporarily set ellipsis PATH so we can load other files.
 ELLIPSIS_PATH="$tmp_dir/ellipsis"
 ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 
 # Initialize ellipsis.
-source $tmp_dir/ellipsis/src/init.bash
+source "$tmp_dir/ellipsis/src/init.bash"
 
 # Load modules.
 load ellipsis
@@ -37,11 +37,11 @@ ELLIPSIS_PATH="$FINAL_ELLIPSIS_PATH"
 ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 
 # Backup existing ~/.ellipsis if necessary and  move project into place.
-fs.backup $ELLIPSIS_PATH
-mv $tmp_dir/ellipsis $ELLIPSIS_PATH
+fs.backup "$ELLIPSIS_PATH"
+mv "$tmp_dir/ellipsis" "$ELLIPSIS_PATH"
 
 # Clean up (only necessary on cygwin, really).
-rm -rf $tmp_dir
+rm -rf "$tmp_dir"
 
 # Backwards compatability, originally referred to packages as modules.
 PACKAGES="${PACKAGES:-$MODULES}"
@@ -68,7 +68,7 @@ echo 'Run `ellipsis help` for additional options.'
 
 if [[ -z "$PACKAGES" ]]; then
     echo
-    if [ $(os.platform) = osx ]; then
+    if [ "$(os.platform)" = osx ]; then
         echo Recommended packages: zeekay/files zeekay/vim zeekay/zsh zeekay/alfred zeekay/iterm2
     else
         echo Recommended packages: zeekay/files zeekay/vim zeekay/zsh

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -18,7 +18,15 @@ proto="${ELLIPSIS_PROTO:-https}"
 url="${ELLIPSIS_REPO:-$proto://github.com/ellipsis/ellipsis.git}"
 
 # Clone ellipsis into $tmp_dir.
-git clone --depth 1 "$url" "$tmp_dir/ellipsis"
+if ! git clone --depth 1 "$url" "$tmp_dir/ellipsis"; then
+    # Clean up
+    rm -rf "$tmp_dir"
+
+    # Print error message
+    echo >&2 "Installation failed!"
+    echo >&2 'Please check $ELLIPSIS_REPO and try again!'
+    exit 1
+fi
 
 # Save reference to specified ELLIPSIS_PATH (if any) otherwise final
 # destination: $HOME/.ellipsis.
@@ -51,7 +59,7 @@ if ! mv "$tmp_dir/ellipsis" "$ELLIPSIS_PATH"; then
 
     # Log error
     log.fail "Installation failed!"
-    msg.print "Please check your ELLIPSIS_PATH and try again!"
+    msg.print 'Please check $ELLIPSIS_PATH and try again!'
     exit 1
 fi
 

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -62,30 +62,26 @@ rm -rf "$tmp_dir"
 PACKAGES="${PACKAGES:-$MODULES}"
 
 if [ "$PACKAGES" ]; then
-    msg.print ""
+    msg.print ''
     for pkg in ${PACKAGES[*]}; do
         msg.bold "Installing $pkg"
         ellipsis.install "$pkg"
     done
 fi
 
-echo
-echo '                                   ~ fin ~                                 '
-echo '   _    _    _                                                             '
-echo '  /\_\ /\_\ /\_\                                                           '
-echo '  \/_/ \/_/ \/_/                         …because $HOME is where the <3 is!'
-echo
-echo 'Be sure to add `export PATH=~/.ellipsis/bin:$PATH` to your bashrc or zshrc.'
-echo
-echo 'Run `ellipsis install <package>` to install a new package.'
-echo 'Run `ellipsis search <query>` to search for packages to install.'
-echo 'Run `ellipsis help` for additional options.'
+msg.print '
+                                   ~ fin ~
+   _    _    _
+  /\_\ /\_\ /\_\
+  \/_/ \/_/ \/_/                         …because $HOME is where the <3 is!
 
-if [[ -z "$PACKAGES" ]]; then
-    echo
-    if [ "$(os.platform)" = osx ]; then
-        msg.print "Recommended packages: zeekay/files zeekay/vim zeekay/zsh zeekay/alfred zeekay/iterm2"
-    else
-        msg.print "Recommended packages: zeekay/files zeekay/vim zeekay/zsh"
-    fi
+Be sure to add `export PATH=~/.ellipsis/bin:$PATH` to your bashrc or zshrc.
+
+Run `ellipsis install <package>` to install a new package.
+Run `ellipsis search <query>` to search for packages to install.
+Run `ellipsis help` for additional options.'
+
+if [ -z "$PACKAGES" ]; then
+    msg.print ''
+    msg.print 'Check http://ellipsis.readthedocs.org/en/master/pkgindex for available packages!'
 fi

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -29,31 +29,42 @@ ELLIPSIS_PATH="$tmp_dir/ellipsis"
 ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 
 # Initialize ellipsis.
-source "$tmp_dir/ellipsis/src/init.bash"
+source "$ELLIPSIS_SRC/init.bash"
 
 # Load modules.
 load ellipsis
 load fs
 load os
-load registry
+load msg
+load log
 
 ELLIPSIS_PATH="$FINAL_ELLIPSIS_PATH"
 ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
 
-# Backup existing ~/.ellipsis if necessary and  move project into place.
+# Backup existing ~/.ellipsis if necessary
 fs.backup "$ELLIPSIS_PATH"
-mv "$tmp_dir/ellipsis" "$ELLIPSIS_PATH"
+
+# Move project into place
+if ! mv "$tmp_dir/ellipsis" "$ELLIPSIS_PATH"; then
+    # Clean up
+    rm -rf "$tmp_dir"
+
+    # Log error
+    log.fail "Installation failed!"
+    msg.print "Please check your ELLIPSIS_PATH and try again!"
+    exit 1
+fi
 
 # Clean up (only necessary on cygwin, really).
 rm -rf "$tmp_dir"
 
-# Backwards compatability, originally referred to packages as modules.
+# Backwards compatibility, originally referred to packages as modules.
 PACKAGES="${PACKAGES:-$MODULES}"
 
 if [ "$PACKAGES" ]; then
+    msg.print ""
     for pkg in ${PACKAGES[*]}; do
-        echo
-        echo -e "\033[1minstalling $pkg\033[0m"
+        msg.bold "Installing $pkg"
         ellipsis.install "$pkg"
     done
 fi
@@ -73,8 +84,8 @@ echo 'Run `ellipsis help` for additional options.'
 if [[ -z "$PACKAGES" ]]; then
     echo
     if [ "$(os.platform)" = osx ]; then
-        echo Recommended packages: zeekay/files zeekay/vim zeekay/zsh zeekay/alfred zeekay/iterm2
+        msg.print "Recommended packages: zeekay/files zeekay/vim zeekay/zsh zeekay/alfred zeekay/iterm2"
     else
-        echo Recommended packages: zeekay/files zeekay/vim zeekay/zsh
+        msg.print "Recommended packages: zeekay/files zeekay/vim zeekay/zsh"
     fi
 fi

--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -13,8 +13,12 @@ done
 # Create temp dir.
 tmp_dir="$(mktemp -d "${TMPDIR:-tmp}"-XXXXXX)"
 
+# Build the repo url
+proto="${ELLIPSIS_PROTO:-https}"
+url="${ELLIPSIS_REPO:-$proto://github.com/ellipsis/ellipsis.git}"
+
 # Clone ellipsis into $tmp_dir.
-git clone --depth 1 git://github.com/ellipsis/ellipsis.git "$tmp_dir/ellipsis"
+git clone --depth 1 "$url" "$tmp_dir/ellipsis"
 
 # Save reference to specified ELLIPSIS_PATH (if any) otherwise final
 # destination: $HOME/.ellipsis.

--- a/test/installer.bats
+++ b/test/installer.bats
@@ -50,6 +50,18 @@ teardown() {
     [ "${lines[0]}" = "ellipsis requires git to be installed." ]
 }
 
+@test "Installer fails in a clean way when cloning fails" {
+    ELLIPSIS_REPO="https://ellipsis:not_valid@github.com/ellipsis/not_valid"\
+    run scripts/install.bash
+
+    # Check output status
+    [ "$status" -eq 1 ]
+
+    # Check messages
+    [ $(expr "$output" : ".*Installation failed!") -ne 0 ]
+    [ $(expr "$output" : '.*Please check $ELLIPSIS_REPO and try again!') -ne 0 ]
+}
+
 @test "Installer fails in a clean way when copying ellipsis fails" {
     # stderr output is disabled to remove git progress messages
     ELLIPSIS_PATH="$TESTS_DIR/tmp/not_valid/not_valid"\
@@ -60,16 +72,12 @@ teardown() {
     [ "$status" -eq 1 ]
 
     # Check messages
-    [ "${lines[10]}" = "Installation failed!" ]
-    [ "${lines[11]}" = "Please check your ELLIPSIS_PATH and try again!" ]
-
-    # Check if tmp dir is cleaned up
-    [ ! -d "${lines[1]}" ]
+    [ $(expr "$output" : ".*Installation failed!") -ne 0 ]
+    [ $(expr "$output" : '.*Please check $ELLIPSIS_PATH and try again!') -ne 0 ]
 }
 
 # Tests multiple things to avoid unnecessary cloning
 @test "Installer correctly 'installs' test project" {
-    # Use/test custom install repository
     # stderr output is disabled to remove git progress messages
     PACKAGES="test1 test2"\
     ELLIPSIS_REPO="https://github.com/ellipsis/installer-test"\
@@ -79,26 +87,27 @@ teardown() {
     [ "$status" -eq 0 ]
 
     # Check if `$ELLIPSIS_PATH` is set correctly
-    [ "${lines[2]}" = "Ellipsis path : $TESTS_DIR/tmp/ellipsis" ]
+    [ $(expr "$output" : ".*Ellipsis path : $TESTS_DIR/tmp/ellipsis") -ne 0 ]
+    #[ "${lines[2]}" = "Ellipsis path : $TESTS_DIR/tmp/ellipsis" ]
 
     # Check if project is installed
     [ -f "$TESTS_DIR/tmp/ellipsis/installer-test" ]
 
     # Check if libs get loaded
-    [ "${lines[3]}" = "load : ellipsis" ]
-    [ "${lines[4]}" = "load : fs" ]
-    [ "${lines[5]}" = "load : os" ]
-    [ "${lines[6]}" = "load : msg" ]
-    [ "${lines[7]}" = "load : log" ]
+    [ $(expr "$output" : ".*load : ellipsis") -ne 0 ]
+    [ $(expr "$output" : ".*load : fs") -ne 0 ]
+    [ $(expr "$output" : ".*load : os") -ne 0 ]
+    [ $(expr "$output" : ".*load : msg") -ne 0 ]
+    [ $(expr "$output" : ".*load : log") -ne 0 ]
 
     # Check if fs.backup is called on the correct dir
-    [ "${lines[8]}" = "fs.backup : $TESTS_DIR/tmp/ellipsis" ]
+    [ $(expr "$output" : ".*fs.backup : $TESTS_DIR/tmp/ellipsis") -ne 0 ]
 
     # Check if packages would be installed
-    [ "${lines[9]}" = "Installing test1" ]
-    [ "${lines[10]}" = "ellipsis.install : test1" ]
-    [ "${lines[11]}" = "Installing test2" ]
-    [ "${lines[12]}" = "ellipsis.install : test2" ]
+    [ $(expr "$output" : ".*Installing test1") -ne 0 ]
+    [ $(expr "$output" : ".*ellipsis.install : test1") -ne 0 ]
+    [ $(expr "$output" : ".*Installing test2") -ne 0 ]
+    [ $(expr "$output" : ".*ellipsis.install : test2") -ne 0 ]
 }
 
 @test "Installer correctly installs ellipsis" {

--- a/test/installer.bats
+++ b/test/installer.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+#
+# Tests for the installation script
+
+setup() {
+    export TESTS_DIR="$BATS_TEST_DIRNAME"
+
+    mkdir -p "$TESTS_DIR/tmp"
+    export ELLIPSIS_PATH="$(cd "$TESTS_DIR/tmp" && pwd)/ellipsis"
+}
+
+teardown() {
+    rm -rf "$TESTS_DIR/tmp"
+}
+
+@test "Installer detects missing dependencies" {
+    # Setup
+    mkdir -p "$TESTS_DIR/tmp/bin/no_bash"
+    touch "$TESTS_DIR/tmp/bin/no_bash/curl"
+    touch "$TESTS_DIR/tmp/bin/no_bash/git"
+
+    mkdir -p "$TESTS_DIR/tmp/bin/no_curl"
+    touch "$TESTS_DIR/tmp/bin/no_curl/bash"
+    touch "$TESTS_DIR/tmp/bin/no_curl/git"
+
+    mkdir -p "$TESTS_DIR/tmp/bin/no_git"
+    touch "$TESTS_DIR/tmp/bin/no_git/bash"
+    touch "$TESTS_DIR/tmp/bin/no_git/curl"
+
+    chmod +x "$TESTS_DIR/tmp/bin" -R
+
+    export BASH="$(which bash)"
+
+    # Bash
+    PATH="$TESTS_DIR/tmp/bin/no_bash"\
+    run "$BASH" scripts/install.bash
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "ellipsis requires bash to be installed." ]
+
+    # Curl
+    PATH="$TESTS_DIR/tmp/bin/no_curl"\
+    run "$BASH" scripts/install.bash
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "ellipsis requires curl to be installed." ]
+
+    # Git
+    PATH="$TESTS_DIR/tmp/bin/no_git"\
+    run "$BASH" scripts/install.bash
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "ellipsis requires git to be installed." ]
+}
+
+@test "Installer fails in a clean way when copying ellipsis fails" {
+    # stderr output is disabled to remove git progress messages
+    ELLIPSIS_PATH="$TESTS_DIR/tmp/not_valid/not_valid"\
+    ELLIPSIS_REPO="https://github.com/ellipsis/installer-test"\
+    run scripts/install.bash 2> /dev/null
+
+    # Check output status
+    [ "$status" -eq 1 ]
+
+    # Check messages
+    [ "${lines[10]}" = "Installation failed!" ]
+    [ "${lines[11]}" = "Please check your ELLIPSIS_PATH and try again!" ]
+
+    # Check if tmp dir is cleaned up
+    [ ! -d "${lines[1]}" ]
+}
+
+# Tests multiple things to avoid unnecessary cloning
+@test "Installer correctly 'installs' test project" {
+    # Use/test custom install repository
+    # stderr output is disabled to remove git progress messages
+    PACKAGES="test1 test2"\
+    ELLIPSIS_REPO="https://github.com/ellipsis/installer-test"\
+    run scripts/install.bash 2> /dev/null
+
+    # Exit status should be ok
+    [ "$status" -eq 0 ]
+
+    # Check if `$ELLIPSIS_PATH` is set correctly
+    [ "${lines[2]}" = "Ellipsis path : $TESTS_DIR/tmp/ellipsis" ]
+
+    # Check if project is installed
+    [ -f "$TESTS_DIR/tmp/ellipsis/installer-test" ]
+
+    # Check if libs get loaded
+    [ "${lines[3]}" = "load : ellipsis" ]
+    [ "${lines[4]}" = "load : fs" ]
+    [ "${lines[5]}" = "load : os" ]
+    [ "${lines[6]}" = "load : msg" ]
+    [ "${lines[7]}" = "load : log" ]
+
+    # Check if fs.backup is called on the correct dir
+    [ "${lines[8]}" = "fs.backup : $TESTS_DIR/tmp/ellipsis" ]
+
+    # Check if packages would be installed
+    [ "${lines[9]}" = "Installing test1" ]
+    [ "${lines[10]}" = "ellipsis.install : test1" ]
+    [ "${lines[11]}" = "Installing test2" ]
+    [ "${lines[12]}" = "ellipsis.install : test2" ]
+}
+
+@test "Installer correctly installs ellipsis" {
+    # Add ellipsis dir to check backup function
+    mkdir -p "$TESTS_DIR/tmp/ellipsis"
+
+    # Script runs without errors
+    run scripts/install.bash
+    [ "$status" -eq 0 ]
+
+    # Original ellipsis dir is preserved
+    [ -d "$TESTS_DIR/tmp/ellipsis.bak" ]
+
+    # Ellipsis is installed and masks possible local installations
+    PATH="$TESTS_DIR/tmp/ellipsis/bin:$PATH"\
+    run which ellipsis
+    [ "$status" -eq 0 ]
+    [ "$output" = "$TESTS_DIR/tmp/ellipsis/bin/ellipsis" ]
+
+    # The installed ellipsis version runs without errors
+    PATH="$TESTS_DIR/tmp/ellipsis/bin:$PATH"\
+    run ellipsis version
+    [ "$status" -eq 0 ]
+    [ $(expr "$output" : "v[0-9][0-9.]*") -ne 0 ]
+}
+


### PR DESCRIPTION
Adds:
- missing quotes
- support for cutom repo urls (uses `$ELLIPSIS_PROTO` or `$ELLIPSIS_REPO` if available)
- proper exiting if copying failed
- proper exiting if cloning failed
- usage of the msg and log functions
- tests
- a reference to the package index from the docs

I replaced the recommended packages message with a reference to the list in the docs. Still not ideal, but until we make a proper implementation of the index system this is probably a better solution.

I would like to use the docs.ellipsis.sh domain for the documentation. Is this possible?
You would need to add a `CNAME` record for `docs.ellipsis.sh` to `readthedocs.org`.

Then we could use `http://docs.ellipsis.sh/pkgindex` which is both shorter and cleaner than the current url. (`http://ellipsis.readthedocs.org/en/master/pkgindex`)