### PR TITLE
Fix upgrading

### DIFF
--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -409,7 +409,7 @@ ellipsis.is_sensitive() {
         $ELLIPSIS_HOME/.ssh|$ELLIPSIS_HOME/.gitconfig|$ELLIPSIS_HOME/.gemrc \
         |$ELLIPSIS_HOME/.npmrc|$ELLIPSIS_HOME/.pypirc|$ELLIPSIS_HOME/.pgpass \
         |$ELLIPSIS_HOME/.floorc|$ELLIPSIS_HOME/.gist|$ELLIPSIS_HOME/.netrc \
-        |$ELLIPSIS_HOME/.git-credential-cache)
+        |$ELLIPSIS_HOME/.git-credential-cache|*history*)
             # Matched files are labled "sensitive"
             return 0
         ;;

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -368,7 +368,7 @@ ellipsis.is_related() {
     fi
 
     case $file in
-        $ELLIPSIS_PATH | $ELLIPSIS_PATH/packages/*)
+        $ELLIPSIS_PATH|$ELLIPSIS_PACKAGES/*)
             # File is ellipsis related
             return 0
             ;;
@@ -384,7 +384,7 @@ ellipsis.is_useless() {
     local file="$1"
 
     case $file in
-        ~/.cache|~/.zcompdump)
+        $ELLIPSIS_HOME/.cache|$ELLIPSIS_HOME/.zcompdump)
             # Matched files are labled "useless"
             return 0
             ;;
@@ -400,7 +400,10 @@ ellipsis.is_sensitive() {
     local file="$1"
 
     case $file in
-        ~/.ssh|~/.gitconfig|~/.gemrc|~/.npmrc|~/.pypirc|~/.pgpass|~/.floorc|~/.gist|~/.netrc|~/.git-credential-cache)
+        $ELLIPSIS_HOME/.ssh|$ELLIPSIS_HOME/.gitconfig|$ELLIPSIS_HOME/.gemrc \
+        |$ELLIPSIS_HOME/.npmrc|$ELLIPSIS_HOME/.pypirc|$ELLIPSIS_HOME/.pgpass \
+        |$ELLIPSIS_HOME/.floorc|$ELLIPSIS_HOME/.gist|$ELLIPSIS_HOME/.netrc \
+        |$ELLIPSIS_HOME/.git-credential-cache)
             # Matched files are labled "sensitive"
             return 0
         ;;

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -368,13 +368,13 @@ ellipsis.is_related() {
     fi
 
     case $file in
-        $ELLIPSIS_PATH | $ELLIPSIS_PATH/pkg/*)
+        $ELLIPSIS_PATH | $ELLIPSIS_PATH/packages/*)
             # File is ellipsis related
-            return 1
+            return 0
             ;;
         *)
             # File is ok for this test
-            return 0
+            return 1
             ;;
     esac
 }
@@ -386,11 +386,11 @@ ellipsis.is_useless() {
     case $file in
         ~/.cache|~/.zcompdump)
             # Matched files are labled "useless"
-            return 1
+            return 0
             ;;
         *)
             # File is ok for this test
-            return 0
+            return 1
         ;;
     esac
 }
@@ -402,11 +402,11 @@ ellipsis.is_sensitive() {
     case $file in
         ~/.ssh|~/.gitconfig|~/.gemrc|~/.npmrc|~/.pypirc|~/.pgpass|~/.floorc|~/.gist|~/.netrc|~/.git-credential-cache)
             # Matched files are labled "sensitive"
-            return 1
+            return 0
         ;;
         *)
             # File is ok for this test
-            return 0
+            return 1
         ;;
     esac
 }

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -364,12 +364,32 @@ ellipsis.is_related() {
 
 # Check if a file is useless
 ellipsis.is_useless() {
-    #TODO: Implementation
-    return false
+    local file="$1"
+
+    case $file in
+        ~/.cache|~/.zcompdump)
+            # Matched files are labled "useless"
+            return true
+        ;;
+        *)
+            # File is ok for this test
+            return false
+        ;;
+    esac
 }
 
 #Check if file is in the list of possibly sensitive files
 ellipsis.is_sensitive() {
-    #TODO: Implementation
-    return false
+    local file="$1"
+
+    case $file in
+        ~/.ssh|~/.gitconfig|~/.gemrc|~/.npmrc|~/.pypirc|~/.pgpass|~/.floorc|~/.gist|~/.netrc|~/.git-credential-cache)
+            # Matched files are labled "sensitive"
+            return true
+        ;;
+        *)
+            # File is ok for this test
+            return false
+        ;;
+    esac
 }

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -320,16 +320,56 @@ ellipsis.clean() {
 # Re-link unlinked packages.
 ellipsis.add() {
     if [ $# -lt 2 ]; then
-        log.fail "Usage: ellipsis add <package> <dotfile>"
+        log.fail "Usage: ellipsis add <package> <(dot)file>"
         exit 1
+    fi
+
+    # Detect explicit additions
+    if [ $# -eq 2 ]; then
+        explicit_add=true
     fi
 
     for file in "${@:2}"; do
         # Important to get absolute path of each file as we'll be changing
         # directory when hook is run.
         local file="$(path.abs_path "$file")"
+        local file_name="$(basename "$file")"
+
+        # Ignore if file is ellipsis related
+        if ellipsis.is_related "$file"; then
+            continue
+        fi
+
+        # Ignore useless files
+        if [ -z "$explicit_add" ] && ellipsis.is_useless "$file"; then
+            continue
+        fi
+
+        # Warn about sensitive files
+        if ellipsis.is_sensitive "$file"; then
+            log.warn "Attention: $file_name might contain sensitive information!"
+        fi
+
         pkg.init "$1"
         pkg.run_hook "add" "$file"
         pkg.del
     done
+}
+
+# Check if a file is related to ellipsis
+ellipsis.is_related() {
+    #TODO: Implementation
+    return false
+}
+
+# Check if a file is useless
+ellipsis.is_useless() {
+    #TODO: Implementation
+    return false
+}
+
+#Check if file is in the list of possibly sensitive files
+ellipsis.is_sensitive() {
+    #TODO: Implementation
+    return false
 }

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -330,6 +330,11 @@ ellipsis.add() {
     fi
 
     for file in "${@:2}"; do
+        # Ignore . and ..
+        if [ "$file" == '.' -o "$file" == '..' ]; then
+            continue
+        fi
+
         # Important to get absolute path of each file as we'll be changing
         # directory when hook is run.
         local file="$(path.abs_path "$file")"
@@ -384,7 +389,8 @@ ellipsis.is_useless() {
     local file="$1"
 
     case $file in
-        $ELLIPSIS_HOME/.cache|$ELLIPSIS_HOME/.zcompdump)
+        $ELLIPSIS_HOME/.cache|$ELLIPSIS_HOME/.zcompdump|$ELLIPSIS_HOME/.ecryptfs \
+        |$ELLIPSIS_HOME/.Private|$ELLIPSIS_HOME/*.bak)
             # Matched files are labled "useless"
             return 0
             ;;

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -214,22 +214,54 @@ teardown() {
 }
 
 @test "ellipsis.is_related should detect ellipsis related files" {
-    skip "No test implementation"
+    # Test specific setup
+    touch "$TESTS_DIR/tmp/test_file"
+    touch "$ELLIPSIS_HOME/test_file"
+    clone_test_package
+    link_test_package
 
-    run ellipsis.is_related
+    run ellipsis.is_related "$TESTS_DIR/tmp/test_file"
+    [ $status -eq 1 ]
+    run ellipsis.is_related "$ELLIPSIS_HOME/test_file"
+    [ $status -eq 1 ]
+    run ellipsis.is_related "$ELLIPSIS_PATH"
+    [ $status -eq 0 ]
+    run ellipsis.is_related "$ELLIPSIS_HOME/.file"
+    [ $status -eq 0 ]
+    run ellipsis.is_related "$ELLIPSIS_PACKAGES/test/ellipsis.sh"
     [ $status -eq 0 ]
 }
 
 @test "ellipsis.is_useless should detect \"useless\" files" {
-    skip "No test implementation"
+    # Test specific setup
+    touch "$TESTS_DIR/tmp/test_file"
+    touch "$ELLIPSIS_HOME/test_file"
 
-    run ellipsis.is_useless
+    run ellipsis.is_useless "$TESTS_DIR/tmp/test_file"
+    [ $status -eq 1 ]
+    run ellipsis.is_useless "$ELLIPSIS_HOME/test_file"
+    [ $status -eq 1 ]
+    run ellipsis.is_useless "$ELLIPSIS_HOME/.cache"
     [ $status -eq 0 ]
+    run ellipsis.is_useless "$ELLIPSIS_HOME/.zcompdump"
+    [ $status -eq 0 ]
+    # Optionally test on all useless files
 }
 
 @test "ellipsis.is_sensitive should detect sensitive files" {
-    skip "No test implementation"
+    # Test specific setup
+    touch "$TESTS_DIR/tmp/test_file"
+    touch "$ELLIPSIS_HOME/test_file"
 
-    run ellipsis.is_sensitive
+    run ellipsis.is_sensitive "$TESTS_DIR/tmp/test_file"
+    [ $status -eq 1 ]
+    run ellipsis.is_sensitive "$ELLIPSIS_HOME/test_file"
+    [ $status -eq 1 ]
+    run ellipsis.is_sensitive "$ELLIPSIS_HOME/.ssh"
     [ $status -eq 0 ]
+    run ellipsis.is_sensitive "$ELLIPSIS_HOME/.gitconfig"
+    [ $status -eq 0 ]
+    run ellipsis.is_sensitive "$ELLIPSIS_HOME/.gemrc"
+    [ $status -eq 0 ]
+    # Optionally test on all sensitive files
 }

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -106,10 +106,6 @@ teardown() {
 }
 
 @test "ellipsis.new should create a new package" {
-    # Test specific setup
-    clone_test_package
-    link_test_package
-
     run ellipsis.new foo
     [ $status -eq 0 ]
     [ -e "$ELLIPSIS_PACKAGES/foo/ellipsis.sh" ]
@@ -207,10 +203,14 @@ teardown() {
 }
 
 @test "ellipsis.add should add files to a package" {
-    skip "No test implementation"
+    # Test specific setup
+    run ellipsis.new foo
 
-    run ellipsis.add
+    run ellipsis.add foo "$ELLIPSIS_HOME/.file"
     [ $status -eq 0 ]
+    [ -L "$ELLIPSIS_HOME/.file" ]
+    [ -e "$ELLIPSIS_PACKAGES/foo/file" ]
+    [ "$(readlink "$ELLIPSIS_HOME/.file")" == "$ELLIPSIS_PACKAGES/foo/file" ]
 }
 
 @test "ellipsis.is_related should detect ellipsis related files" {

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -205,3 +205,31 @@ teardown() {
     run ellipsis.push
     [ $status -eq 0 ]
 }
+
+@test "ellipsis.add should add files to a package" {
+    skip "No test implementation"
+
+    run ellipsis.add
+    [ $status -eq 0 ]
+}
+
+@test "ellipsis.is_related should detect ellipsis related files" {
+    skip "No test implementation"
+
+    run ellipsis.is_related
+    [ $status -eq 0 ]
+}
+
+@test "ellipsis.is_useless should detect \"useless\" files" {
+    skip "No test implementation"
+
+    run ellipsis.is_useless
+    [ $status -eq 0 ]
+}
+
+@test "ellipsis.is_sensitive should detect sensitive files" {
+    skip "No test implementation"
+
+    run ellipsis.is_sensitive
+    [ $status -eq 0 ]
+}

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -252,6 +252,7 @@ teardown() {
     # Test specific setup
     touch "$TESTS_DIR/tmp/test_file"
     touch "$ELLIPSIS_HOME/test_file"
+    touch "$ELLIPSIS_HOME/test_file.history"
 
     run ellipsis.is_sensitive "$TESTS_DIR/tmp/test_file"
     [ $status -eq 1 ]
@@ -264,4 +265,7 @@ teardown() {
     run ellipsis.is_sensitive "$ELLIPSIS_HOME/.gemrc"
     [ $status -eq 0 ]
     # Optionally test on all sensitive files
+
+    run ellipsis.is_sensitive "$ELLIPSIS_HOME/test_file.history"
+    [ $status -eq 0 ]
 }


### PR DESCRIPTION
Fixes #50 (finally)

- Adds checks for ellipsis related, useless and sensitive files
- Ellipsis files are ignored
- Useless files are ignored with message, over-writable by explicit addition (single file)
- Sensitive files are added with warning
- `.` and `..` are ignored
- Includes tests