### PR TITLE
Add support for failing install hooks (dependency checks)

### DIFF
--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -98,7 +98,14 @@ ellipsis.install() {
         fi
 
         pkg.env_up "$PKG_PATH"
+
         pkg.run_hook "install"
+        if [ "$?" -ne 0 ]; then
+            rm -rf "$PKG_PATH"
+            log.fail "Could not install package $PKG_NAME"
+            exit 1
+        fi
+
         pkg.run_hook "link"
         pkg.env_down
     done

--- a/src/env.sh
+++ b/src/env.sh
@@ -6,7 +6,8 @@
 # Call functions from the ellipsis API
 # Note: this is relatively slow, and should be avoided if possible
 env_api() {
-    ELLIPSIS_INIT=1 bash "$ELLIPSIS_BIN/ellipsis" api "$@"
+    # Explicitly use bash by calling the bash scipt
+    bash "$ELLIPSIS_BIN/ellipsis" api "$@"
 }
 
 # PATH helper, if exists, prepend, no duplication
@@ -27,6 +28,7 @@ env_append_path() {
 
 env_init_ellipsis() {
     # Changeable globals
+    export ELLIPSIS_INIT
     export ELLIPSIS_HOME
     export ELLIPSIS_PATH
     export ELLIPSIS_USER

--- a/src/pkg.bash
+++ b/src/pkg.bash
@@ -103,8 +103,13 @@ pkg.run() {
     # run command
     "$@"
 
+    # keep return value
+    local return_code="$?"
+
     # return after running command
     cd "$cwd"
+
+    return "$return_code"
 }
 
 # run hook if it's defined, otherwise use default implementation


### PR DESCRIPTION
This change makes it possible to check for dependencies in the install
hook for a package. If the hook returns a non zero exit status the
installation is aborted and logged as failed. Already downloaded files
are removed.

`ELLIPSIS_INIT` is now also exported so it's possible to check for the ellipsis init system as a dependency.