### PR TITLE
Auto check for ELLIPSIS_VERSION_DEP if defined

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -52,6 +52,8 @@ The `pkg.install` hook lets you run custom install steps. The hook is run after
 cloning the repo.
 This is the place to install plugin managers, dependencies,...
 
+If the install hook returns with return code 1, the installation is aborted.
+
 ##### pkg.link
 The `pkg.link` hook lets you customize which files are linked. It is recommended
 to use the `fs.link_file` function, because it provides backup capability's.
@@ -91,7 +93,7 @@ functions, aliases, exports,... to the environment. The ellipsis api won't be
 directly available from this hook. You can use the `ellipsis api` command to
 access it, but for performance reasons it's not recommended.
 
-**Attention:** As this code will be sourced be the users shell (which could be
+**Attention:** As this code will be sourced by the users shell (which could be
 any shell), this hook should be written with POSIX compliancy in mind!
 
 #### Examples

--- a/docs/init.md
+++ b/docs/init.md
@@ -12,7 +12,7 @@ file (bashrc, zshrc,...).
 if [ -f ~/.ellipsis/init.sh ]; then
     . ~/.ellipsis/init.sh
 else
-    export PATH=$PATH:~/.ellipsis/bin
+    export PATH="$PATH:~/.ellipsis/bin"
 fi
 ```
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -15,5 +15,16 @@ You can customize how ellipsis interacts with your package by adding an
 
 Yep, that's it :) If all you want to do is symlink some files into `$HOME`,
 adding an `ellipsis.sh` to your package is completely optional. But what if you
-need more? That's where hooks come in...
+need more? That's where [hooks][hooks] come in!
 
+The `ellipsis.sh` file also lets you specify the minimal Ellipsis version
+needed to use your package. This can be done by defining the
+`ELLIPSIS_VERSION_DEP` variable.
+
+```bash
+#!/usr/bin/env bash
+
+ELLIPSIS_VERSION_DEP="1.8.0"
+```
+
+[hooks]:         hooks.md

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -99,10 +99,19 @@ ellipsis.install() {
 
         pkg.env_up "$PKG_PATH"
 
+        # Check for ellipsis version dependency if defined
+        if [ -n "$ELLIPSIS_VERSION_DEP" ] &&
+            utils.version_compare "$ELLIPSIS_VERSION" -lt "$ELLIPSIS_VERSION_DEP"; then
+
+            log.fail "Package $PKG_NAME needs at least Ellipsis version $ELLIPSIS_VERSION_DEP"
+            rm -rf "$PKG_PATH"
+            exit 1
+        fi
+
         pkg.run_hook "install"
         if [ "$?" -ne 0 ]; then
-            rm -rf "$PKG_PATH"
             log.fail "Could not install package $PKG_NAME"
+            rm -rf "$PKG_PATH"
             exit 1
         fi
 

--- a/src/pkg.bash
+++ b/src/pkg.bash
@@ -139,6 +139,7 @@ pkg.env_down() {
 pkg._unset_vars() {
     unset PKG_NAME
     unset PKG_PATH
+    unset ELLIPSIS_VERSION_DEP
 }
 
 # Unset any hooks that might have been defined by package.


### PR DESCRIPTION
This was already available for extensions, but I think it's useful for packages too.
(optional and backwards compatible)