### PR TITLE
Fix add remove symmetry

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -15,19 +15,20 @@ pkg.install() {
 
 The hooks available in your `ellipsis.sh` are:
 
-| Hook             | Description                                                       |
-|------------------|-------------------------------------------------------------------|
-| `pkg.init`       | Run custom init code when a shell is spawned.                     |
-| `pkg.add`        | Customizes how files are added to your package.                   |
-| `pkg.install`    | Custom installation steps before linking the package.             |
-| `pkg.installed`  | Customize how a package is listed as installed.                   |
-| `pkg.link`       | Customizes which files are linked into `$ELLIPSIS_HOME`.          |
-| `pkg.links`      | Customizes which files are detected as symlinks.                  |
-| `pkg.pull`       | Customize how changes are pulled in when `ellipsis pull` is used. |
-| `pkg.push`       | Customize how changes are pushed when `ellipsis push` is used.    |
-| `pkg.status`     | Customize the output of `ellipsis status`.                        |
-| `pkg.uninstall`  | Custom uninstall steps to undo the install steps.                 |
-| `pkg.unlink`     | Customize which files are unlinked by your package.               |
+| Hook            | Description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| `pkg.init`      | Run custom init code when a shell is spawned.                     |
+| `pkg.add`       | Customizes how files are added to your package.                   |
+| `pkg.remove`    | Customizes how files are removed from your package.               |
+| `pkg.install`   | Custom installation steps before linking the package.             |
+| `pkg.installed` | Customize how a package is listed as installed.                   |
+| `pkg.link`      | Customizes which files are linked into `$ELLIPSIS_HOME`.          |
+| `pkg.links`     | Customizes which files are detected as symlinks.                  |
+| `pkg.pull`      | Customize how changes are pulled in when `ellipsis pull` is used. |
+| `pkg.push`      | Customize how changes are pushed when `ellipsis push` is used.    |
+| `pkg.status`    | Customize the output of `ellipsis status`.                        |
+| `pkg.uninstall` | Custom uninstall steps to undo the install steps.                 |
+| `pkg.unlink`    | Customize which files are unlinked by your package.               |
 
 Lets look at this in more detail!
 

--- a/src/cli.bash
+++ b/src/cli.bash
@@ -69,10 +69,13 @@ cli.run() {
         add)
             ellipsis.add "${@:2}"
             ;;
+        remove|rm)
+            ellipsis.remove "${@:2}"
+            ;;
         install|in)
             ellipsis.install "${@:2}"
             ;;
-        uninstall|remove|rm)
+        uninstall|un)
             ellipsis.uninstall $2
             ;;
         broken)

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -339,7 +339,7 @@ ellipsis.clean() {
     done
 }
 
-# Re-link unlinked packages.
+# Add file to package
 ellipsis.add() {
     if [ $# -lt 2 ]; then
         log.fail "Usage: ellipsis add <package> <(dot)file>"
@@ -381,6 +381,30 @@ ellipsis.add() {
 
         pkg.env_up "$1"
         pkg.run_hook "add" "$file"
+        pkg.env_down
+    done
+}
+
+# Remove file from package
+ellipsis.remove() {
+    if [ $# -lt 2 ]; then
+        log.fail "Usage: ellipsis remove <package> <(dot)file>"
+        exit 1
+    fi
+
+    for file in "${@:2}"; do
+        # Ignore . and ..
+        if [ "$file" == '.' -o "$file" == '..' ]; then
+            continue
+        fi
+
+        # Important to get absolute path of each file as we'll be changing
+        # directory when hook is run.
+        local file="$(path.abs_path "$file")"
+        local file_name="$(basename "$file")"
+
+        pkg.env_up "$1"
+        pkg.run_hook "remove" "$file"
         pkg.env_down
     done
 }

--- a/src/utils.bash
+++ b/src/utils.bash
@@ -10,7 +10,11 @@ utils.cmd_exists() {
 # prompt with message and return true if yes/YES, otherwise false
 utils.prompt() {
     read -r -p "$1 " answer
-    return utils.is_true "$answer"
+
+    if ! utils.is_true "$answer"; then
+        return 1
+    fi
+    return 0
 }
 
 # Run web-based installers

--- a/test/ellipsis.bats
+++ b/test/ellipsis.bats
@@ -213,6 +213,18 @@ teardown() {
     [ "$(readlink "$ELLIPSIS_HOME/.file")" == "$ELLIPSIS_PACKAGES/foo/file" ]
 }
 
+@test "ellipsis.remove should remove files from a package" {
+    # Test specific setup
+    run ellipsis.new foo
+    run ellipsis.add foo "$ELLIPSIS_HOME/.file"
+
+    run ellipsis.remove foo "$ELLIPSIS_HOME/.file"
+    [ $status -eq 0 ]
+    [ -f "$ELLIPSIS_HOME/.file" ]
+    [ ! -L "$ELLIPSIS_HOME/.file" ]
+    [ ! -e "$ELLIPSIS_PACKAGES/foo/file" ]
+}
+
 @test "ellipsis.is_related should detect ellipsis related files" {
     # Test specific setup
     touch "$TESTS_DIR/tmp/test_file"

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -22,6 +22,11 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "hooks.remove" {
+    skip "No test implementation"
+    [ "$status" -eq 0 ]
+}
+
 @test "hooks.install should exist" {
     run hooks.install
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes #51 

Adds a new implementation for `ellipsis remove`, which now removes files from a package.

The requested safety for not accidentally trowing away uncommitted changes wil be added to the `uninstall` command in a future PR.

I also included a bugfix for `utils.prompt`, which complained about the return code not being numerical.