### PR TITLE
Improve uninstall safety

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -23,7 +23,9 @@ variables which ellipsis exposes for you:
 | `fs.strip_dot`              | Removes `.` prefix from files in a given directory.                                  |
 | `git.clone`                 | Clones a Git repo, identical to `git clone`.                                         |
 | `git.diffstat`              | Displays `git diff --stat`.                                                          |
+| `git.status`                | Displays `git status -s`.                                                          |
 | `git.has_changes`           | Returns true if repository has changes.                                              |
+| `git.has_untracked`         | Returns true if repository has untracked files.                                              |
 | `git.head`                  | Prints how far ahead a package is from origin.                                       |
 | `git.last_updated`          | Prints commit's relative last update time.                                           |
 | `git.pull`                  | Identical to `git pull`.                                                             |
@@ -37,6 +39,7 @@ variables which ellipsis exposes for you:
 | `path.relative_to_packages` | Strips `$ELLIPSIS_PACKAGES` from path.                                               |
 | `path.strip_dot`            | Strip dot from hidden files/folders.                                                 |
 | `utils.cmd_exists`          | Returns true if command exists.                                                      |
+| `utils.is_interactive`      | Returns true if ellipsis is running in an interactive terminal.
 | `utils.prompt`              | Prompts user `$1` message and returns true if `YES` or `yes` is input.               |
 | `utils.run_installer`       | Downloads and runs web-based shell script installers.                                |
 | `utils.version_compare`     | Compare version strings. Usage: `utils.version_compare "$Version1" ">=" "1.2.4"`.    |
@@ -222,8 +225,26 @@ TODO
 ```
 ---
 
+<h5>git.status</h5>
+Displays `git status -s`.
+
+``` bash
+# example ()
+TODO
+```
+---
+
 <h5>git.has_changes</h5>
 Returns true if repository has changes.
+
+``` bash
+# example ()
+TODO
+```
+---
+
+<h5>git.has_untracked</h5>
+Returns true if repository has untracked files.
 
 ``` bash
 # example ()
@@ -347,6 +368,15 @@ TODO
 
 <h5>utils.cmd_exists</h5>
 Returns true if command exists.
+
+``` bash
+# example ()
+TODO
+```
+---
+
+<h5>utils.is_interactive</h5>
+Returns true if ellipsis is running in an interactive terminal.
 
 ``` bash
 # example ()

--- a/docs/api.md
+++ b/docs/api.md
@@ -357,6 +357,9 @@ TODO
 <h5>utils.prompt</h5>
 Prompts user `$1` message and returns true if `YES` or `yes` is input.
 
+A default answer can be provided as a second argument. If there is no
+controlling terminal, this will be used instead of asking for input.
+
 ``` bash
 # example ()
 TODO

--- a/src/cli.bash
+++ b/src/cli.bash
@@ -23,6 +23,7 @@ Usage: ellipsis <command>
     new        create a new package
     edit       edit an installed package
     add        add new dotfile to package
+    remove     remove a files form a package
     install    install new package
     uninstall  uninstall package
     link       link package
@@ -76,7 +77,7 @@ cli.run() {
             ellipsis.install "${@:2}"
             ;;
         uninstall|un)
-            ellipsis.uninstall $2
+            ellipsis.uninstall "${@:2}"
             ;;
         broken)
             ellipsis.broken $2

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -128,11 +128,22 @@ ellipsis.uninstall() {
         exit 1
     fi
 
-    pkg.env_up "$1"
-    pkg.run_hook "unlink"
-    pkg.run_hook "uninstall"
-    rm -rf "$PKG_PATH"
-    pkg.env_down
+    for package in "$@"; do
+        pkg.env_up "$package"
+
+        if pkg.run git.has_untracked || pkg.run git.has_changes; then
+            if ! utils.prompt "Uncommitted files or changes present, continue? [y/n]" "y"; then
+                pkg.env_down
+                continue
+            fi
+        fi
+
+        pkg.run_hook "unlink"
+        pkg.run_hook "uninstall"
+        rm -rf "$PKG_PATH"
+
+        pkg.env_down
+    done
 }
 
 # Re-link unlinked packages.

--- a/src/ellipsis.bash
+++ b/src/ellipsis.bash
@@ -221,7 +221,7 @@ ellipsis.new() {
 
     # If path is not empty, ensure they are serious.
     if ! $(fs.folder_empty "$PKG_PATH"); then
-        utils.prompt "destination is not empty, continue? [y/n]" || exit 1
+        utils.prompt "destination is not empty, continue? [y/n]" "y" || exit 1
     fi
 
     # Template variables.

--- a/src/git.bash
+++ b/src/git.bash
@@ -44,6 +44,9 @@ git.ahead() {
 
 # Check whether get repo has changes.
 git.has_changes() {
+    # Refresh index before using it
+    git update-index --refresh 2>&1 > /dev/null
+
     if git diff-index --quiet HEAD --; then
         return 1
     fi
@@ -62,6 +65,11 @@ git.has_untracked() {
 # Print diffstat for git repo
 git.diffstat() {
     git --no-pager diff --stat --color=always
+}
+
+# Print status for git repo
+git.status() {
+    git status -s
 }
 
 # Checks if git is configured as we expect.

--- a/src/git.bash
+++ b/src/git.bash
@@ -50,6 +50,15 @@ git.has_changes() {
     return 0
 }
 
+# Check for untracked files
+# ! Only works if the pwd is the root of the repo
+git.has_untracked() {
+    if [ -z "$(git ls-files -o --exclude-standard)" ]; then
+        return 1
+    fi
+    return 0
+}
+
 # Print diffstat for git repo
 git.diffstat() {
     git --no-pager diff --stat --color=always

--- a/src/hooks.bash
+++ b/src/hooks.bash
@@ -132,11 +132,11 @@ hooks.status() {
     local ahead="$(git.ahead)"
 
     # Return unless there are changes or we are behind.
-    git.has_changes || [ "$ahead" ] || return
+    git.has_changes || git.has_untracked || [ "$ahead" ] || return
 
     local sha1="$(git.sha1)"
     local last_updated="$(git.last_updated)"
 
     msg.print "\033[1m${1:-$PKG_NAME}\033[0m $sha1 (updated $last_updated) $ahead"
-    git.diffstat
+    git.status
 }

--- a/src/utils.bash
+++ b/src/utils.bash
@@ -7,24 +7,29 @@ utils.cmd_exists() {
     hash "$1" &> /dev/null
 }
 
+# Check for interactive tty
+utils.is_interactive() {
+    if [ ! -t 1 ]; then
+        return 1
+    fi
+    return 0
+}
+
 # prompt with message and return true if yes/YES, otherwise false
 # If a default is provided, there will be no prompt in a non interactive terminal
 utils.prompt() {
     local prompt="$1"
     local default="$2"
 
-    case $- in
-        *i*)    # interactive shell
+    if utils.is_interactive || utils.is_true "$ELLIPSIS_FORCE_PROMPT"; then
+        read -r -p "$prompt " answer
+    else
+        if [ -z "$default" ]; then
             read -r -p "$prompt " answer
-            ;;
-        *)      # non-interactive shell
-            if [ -z "$default" ]; then
-                read -r -p "$prompt " answer
-            else
-                answer="$default"
-            fi
-            ;;
-    esac
+        else
+            answer="$default"
+        fi
+    fi
 
     if ! utils.is_true "$answer"; then
         return 1

--- a/src/utils.bash
+++ b/src/utils.bash
@@ -8,8 +8,23 @@ utils.cmd_exists() {
 }
 
 # prompt with message and return true if yes/YES, otherwise false
+# If a default is provided, there will be no prompt in a non interactive terminal
 utils.prompt() {
-    read -r -p "$1 " answer
+    local prompt="$1"
+    local default="$2"
+
+    case $- in
+        *i*)    # interactive shell
+            read -r -p "$prompt " answer
+            ;;
+        *)      # non-interactive shell
+            if [ -z "$default" ]; then
+                read -r -p "$prompt " answer
+            else
+                answer="$default"
+            fi
+            ;;
+    esac
 
     if ! utils.is_true "$answer"; then
         return 1

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -12,6 +12,14 @@ teardown() {
     rm -rf tmp
 }
 
+utils_prompt_yes() {
+    echo y | utils.prompt "select yes"
+}
+
+utils_prompt_no() {
+    echo n | utils.prompt "select no"
+}
+
 @test "utils.cmd_exists should find command in PATH" {
     run utils.cmd_exists bats
     [ $status -eq 0 ]
@@ -22,15 +30,23 @@ teardown() {
     [ $status -eq 1 ]
 }
 
-@test "utils.prompt should return true if yes otherwise no" {
-    skip "No test implementation"
-    run echo y | utils.prompt "select yes"
+@test "utils.prompt should return true if yes" {
+    run utils_prompt_yes
     [ $status -eq 0 ]
 }
 
-@test "utils.prompt should return true if yes otherwise no" {
-    skip "No test implementation"
-    run echo n | utils.prompt "select yes"
+@test "utils.prompt should return false if not true" {
+    run utils_prompt_no
+    [ $status -eq 1 ]
+}
+
+@test "utils.prompt should return true if no terminal and default true" {
+    run utils.prompt "select yes" "yes"
+    [ $status -eq 0 ]
+}
+
+@test "utils.prompt should return false if no terminal and default false" {
+    run utils.prompt "select yes" "no"
     [ $status -eq 1 ]
 }
 


### PR DESCRIPTION
Some small improvements that should make the `uninstall` command a lot safer.

Most notable change in the PR is the `ellipsis status` command now uses `git status -s` instead of `git diff --stat`.

The problem with diff stat is that it doesn't provide information about untracked files or uncommitted changes. The `uninstall` command would then prompt that there are changes, but `ellipsis status` would show none. For this reason I switched the nicer diff stat output for the more complete status output.