### PR TITLE
Added wget command for installing Ellipsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ Ellipsis is a package manager for dotfiles.
 - [Works with existing dotfiles!][docs-upgrading]
 
 ### Install
-**Requirements:** bash, curl, git
+**Requirements:** bash, curl/wget, git
 
 Clone and symlink or use handy-dandy installer:
 
 ```bash
 $ curl -sL ellipsis.sh | sh
+```
+or
+```bash
+$ wget -qO- ellipsis.sh | sh
 ```
 
 <sup>...no you didn't read that wrong, [the ellipsis.sh website also doubles as the installer][installer]</sup>
@@ -66,7 +70,7 @@ You can customize ellipsis by exporting a few different variables:
 | Variable                        | Description                                                                                                                                                          |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `GITHUB_USER` / `ELLIPSIS_USER` | Customizes whose dotfiles are installed when you `ellipsis install` without specifying user or a full repo url. Defaults to `$(git config github.user)` or `whoami`. |
-| `ELLIPSIS_REPO`                 | Customize location of ellipsis repo cloned during a curl-based install. Defaults to `https://github.com/ellipsis/ellipsis`.                                          |
+| `ELLIPSIS_REPO`                 | Customize location of ellipsis repo cloned during a curl/wget-based install. Defaults to `https://github.com/ellipsis/ellipsis`.                                          |
 | `ELLIPSIS_PROTO`                | Customizes which protocol new packages are cloned with, you can specify `https`,`ssh`, `git`. Defaults to `https`.                                                   |
 | `ELLIPSIS_HOME`                 | Customize which folder files are symlinked into, defaults to `$HOME`. (Mostly useful for testing)                                                                    |
 | `ELLIPSIS_PATH`                 | Customize where ellipsis lives on your filesystem, defaults to `~/.ellipsis`.                                                                                        |


### PR DESCRIPTION
I was installing [stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/) earlier today, and realized that the same wget command would probably work for installing Ellipsis.