### PR TITLE
Ellipsis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+  - osx
 language: node_js
 node_js:
   - 0.10

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,7 @@ variables which ellipsis exposes for you:
 | `fs.list_dirs`              | Lists directories, useful for passing subdirectories to `fs.link_files`.             |
 | `fs.list_symlinks`          | Lists symlinks in a folder, defaulting to `$ELLIPSIS_HOME`.                          |
 | `fs.strip_dot`              | Removes `.` prefix from files in a given directory.                                  |
+| `fs.source_first`           | Sources (and echo's) first file found.                                               |
 | `git.behind`                | Prints number of commits local is behind remote.                                     |
 | `git.clone`                 | Clones a Git repo, identical to `git clone`.                                         |
 | `git.diffstat`              | Displays `git diff --stat`.                                                          |
@@ -41,7 +42,7 @@ variables which ellipsis exposes for you:
 | `path.relative_to_packages` | Strips `$ELLIPSIS_PACKAGES` from path.                                               |
 | `path.strip_dot`            | Strip dot from hidden files/folders.                                                 |
 | `utils.cmd_exists`          | Returns true if command exists.                                                      |
-| `utils.is_interactive`      | Returns true if ellipsis is running in an interactive terminal.
+| `utils.is_interactive`      | Returns true if ellipsis is running in an interactive terminal.                      |
 | `utils.prompt`              | Prompts user `$1` message and returns true if `YES` or `yes` is input.               |
 | `utils.run_installer`       | Downloads and runs web-based shell script installers.                                |
 | `utils.version_compare`     | Compare version strings. Usage: `utils.version_compare "$Version1" ">=" "1.2.4"`.    |
@@ -204,6 +205,15 @@ Removes `.` prefix from files in a given directory.
 ``` bash
 # example ()
 TODO
+```
+---
+
+<h5>fs.source_first</h5>
+Sources the first found file in a list. The sourced file will be echoed. If no
+file found return code will be 1.
+
+``` bash
+fs.source_first 'file1' '/tmp/file2' "$HOME/file3" || echo "No file found"
 ```
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,6 +40,8 @@ Usage: ellipsis <command>
     status     show status of package(s)
     publish    publish package to repository
     search     search package repository
+    strip      strip . from filenames
+    info       show ellipsis info
 ```
 
 ### Configuration

--- a/src/cli.bash
+++ b/src/cli.bash
@@ -38,6 +38,7 @@ Usage: ellipsis <command>
     publish    publish package to repository
     search     search package repository
     strip      strip . from filenames
+    info       show ellipsis info
 EOF
 }
 
@@ -52,8 +53,41 @@ cli.version() {
     cd "$cwd"
 }
 
+cli.info() {
+    cli.version
+    msg.print "  Home: $ELLIPSIS_HOME"
+    msg.print "  User: $ELLIPSIS_USER"
+    msg.print "  Init: $ELLIPSIS_INIT"
+    msg.print "  Path: $ELLIPSIS_PATH"
+    msg.print "  Config: $ELLIPSIS_CCONFIG"
+    msg.print "  Packages: $ELLIPSIS_PACKAGES"
+}
+
+cli.load_config() {
+    local config_paths=()
+
+    if [ -n "$ELLIPSIS_CONFIG" ]; then
+        config_paths+=("$ELLIPSIS_CONFIG")
+    fi
+
+    if [ -n "$XDG_CONFIG_HOME" ]; then
+        config_paths+=("$XDG_CONFIG_HOME/ellipsisrc")
+        config_paths+=("$XDG_CONFIG_HOME/ellipsis/ellipsisrc")
+    fi
+
+    config_paths+=("$HOME/.ellipsisrc")
+    config_paths+=("$HOME/.ellipsis/ellipsisrc")
+
+    ELLIPSIS_CCONFIG="$(fs.source_first "${config_paths[@]}")"
+    if [ "$?" -eq 0 ]; then
+        ELLIPSIS_CCONFIG="$(path.abs_path "$ELLIPSIS_CCONFIG")"
+    fi
+}
+
 # run ellipsis
 cli.run() {
+    cli.load_config
+
     case "$1" in
         api)
             ellipsis.api "${@:2}"
@@ -123,6 +157,9 @@ cli.run() {
             ;;
         version|--version|-v)
             cli.version
+            ;;
+        info)
+            cli.info
             ;;
         *)
             if [ $# -gt 0 ]; then

--- a/src/fs.bash
+++ b/src/fs.bash
@@ -146,3 +146,15 @@ fs.strip_dot() {
         mv "$file" "$dir/$stripped"
     done
 }
+
+# source first found
+fs.source_first() {
+    for file in "$@"; do
+        if [ -f "$file" ]; then
+            echo "$file"
+            source "$file"
+            return 0
+        fi
+    done
+    return 1
+}

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -3,6 +3,30 @@
 load _helper
 load cli
 
+@test "cli.usage shows usage info" {
+  skip "No test implementation"
+  run cli.usage
+  [ "$status" -eq 0 ]
+}
+
+@test "cli.version prints version" {
+  skip "No test implementation"
+  run cli.version
+  [ "$status" -eq 0 ]
+}
+
+@test "cli.info shows ellipsis info" {
+  skip "No test implementation"
+  run cli.info
+  [ "$status" -eq 0 ]
+}
+
+@test "cli.load_config sources first found config file" {
+  skip "No test implementation"
+  run cli.load_config
+  [ "$status" -eq 0 ]
+}
+
 @test "cli.run without command prints usage" {
   run cli.run
   [ "$status" -eq 1 ]

--- a/test/fs.bats
+++ b/test/fs.bats
@@ -139,3 +139,25 @@ teardown() {
     run fs.is_ellipsis_symlink $ELLIPSIS_HOME/.test
     [ $status -eq 0 ]
 }
+
+@test "fs.source_first should source first file found in filelist" {
+    # Setup
+    mkdir -p tmp/source_files
+    echo "TEST_VAR=file2" > tmp/source_files/file2
+    echo "TEST_VAR=file3" > tmp/source_files/file3
+    test_source_first(){
+        fs.source_first "$@"
+        echo "$TEST_VAR"
+    }
+
+    # Test successful source
+    run test_source_first tmp/source_files/file1 tmp/source_files/file2 tmp/source_files/file3
+    [ $status -eq 0 ]
+    [ "${lines[0]}" == "tmp/source_files/file2" ]
+    [ "${lines[1]}" == "file2" ]
+
+    # Test failing source
+    run fs.source_first does_not_exist_1 does_not_exist_2
+    [ $status -eq 1 ]
+    [ "$output" = "" ]
+}


### PR DESCRIPTION
Adds config/rc file support. This will allow users to keep settings in there own config file.

Because we are just sourcing the file, it's also possible to hack-away and overwrite functions and do other fun stuff for more advanced users. Docs will follow once I have some more experience with the feature (as we did in the past).

I've also added an `info` command to do basic troubleshooting and for checking if ellipsis uses all correct settings.

The change in `.travis.yml` will hopefully work from the first time and auto check for both linux and osx. But I don't have much experience with this feature.
