### PR TITLE
Fix quick install with packages

### DIFF
--- a/scripts/install.bash
+++ b/scripts/install.bash
@@ -46,8 +46,12 @@ load os
 load msg
 load log
 
+# Set paths to final location
 ELLIPSIS_PATH="$FINAL_ELLIPSIS_PATH"
+ELLIPSIS_BIN="$ELLIPSIS_PATH/bin"
 ELLIPSIS_SRC="$ELLIPSIS_PATH/src"
+
+ELLIPSIS_PACKAGES="$ELLIPSIS_PATH/packages"
 
 # Backup existing ~/.ellipsis if necessary
 fs.backup "$ELLIPSIS_PATH"


### PR DESCRIPTION
`$ELLIPSIS_PACKAGES` was not set to the correct value during the
install. This made Ellipsis install the packages in the tmp install
directory.

The issue is fixed by setting the `$ELLIPSIS_PACKAGES` variable to its
correct value after installing Ellipsis itself.

Fixes #78 