### PR TITLE
Add fs.link_rfiles function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,9 +15,10 @@ variables which ellipsis exposes for you:
 | `fs.is_broken_symlink`      | Returns true if file is a broken symlink.                                            |
 | `fs.is_ellipsis_symlink`    | Returns true if file is a symlink pointing to an ellipsis package.                   |
 | `fs.is_symlink`             | Returns true if file is a symlink.                                                   |
-| `fs.link_rfile`             | Symlinks a single (regular) file into `$ELLIPSIS_HOME`.                              |
-| `fs.link_file`              | Symlinks a single (dot) file into `$ELLIPSIS_HOME`.                                  |
-| `fs.link_files`             | Symlinks all files in given folder into `$ELLIPSIS_HOME`.                            |
+| `fs.link_rfile`             | Symlinks a single file.                                                              |
+| `fs.link_file`              | Symlinks a single file and prepends a dot.                                           |
+| `fs.link_rfiles`            | Symlinks all files in a given folder.                                                |
+| `fs.link_files`             | Symlinks all files in a given folder and prepends a dot.                             |
 | `fs.list_dirs`              | Lists directories, useful for passing subdirectories to `fs.link_files`.             |
 | `fs.list_symlinks`          | Lists symlinks in a folder, defaulting to `$ELLIPSIS_HOME`.                          |
 | `fs.strip_dot`              | Removes `.` prefix from files in a given directory.                                  |
@@ -141,13 +142,15 @@ fi
 ---
 
 <h5>fs.link_rfile</h5>
-Symlinks a single (regular) file into `$ELLIPSIS_HOME`.
+Symlinks a single file.
 
-By default the file will be symlinked into `$HOME`, but another location can be
-provided as a second parameter.
+By default the file will be symlinked into `$ELLIPSIS_HOME`, but another location can be
+provided as a second parameter (including filename).
+
+A backup will be made if the destination exists.
 
 ``` bash
-# example (Links 'file' to 'file' in $HOME)
+# example (Links 'file' to 'file' in $ELLIPSIS_HOME)
 fs.link_rfile file
 
 # example (Links 'file' to 'other_file' in $HOME)
@@ -156,28 +159,50 @@ fs.link_rfile file $HOME/other_file
 ---
 
 <h5>fs.link_file</h5>
-Symlinks a single (dot) file into `$ELLIPSIS_HOME`. A dot will be prepended if
-needed.
+Symlinks a single file and prepends a dot if needed.
 
-By default the file will be symlinked into `$HOME`, but another location can be
-provided as a second parameter. If you provide a destination there won't be a
+By default the file will be symlinked into `$ELLIPSIS_HOME`, but another location can be
+provided as a second parameter (including filename). If you provide a destination there won't be a
 dot prepended.
 
+A backup will be made if the destination exists.
+
 ``` bash
-# example (Links 'file' to '.file' in $HOME)
+# example (Links 'file' to '.file' in $ELLIPSIS_HOME)
 fs.link_file file
 
 # example (Links 'file' to '.other_file' in $HOME)
-fs.link_rfile file $HOME/.other_file
+fs.link_file file $HOME/.other_file
+```
+---
+
+<h5>fs.link_rfiles</h5>
+Calls `fs.link_rfile` for all files in a given directory.
+
+The function accepts an optional second parameter to link to another directory
+then `$ELLIPSIS_HOME`.
+
+``` bash
+# example (Links all files in 'dir' to $ELLIPSIS_HOME)
+fs.link_files dir
+
+# example (Links all files in 'dir' to $HOME/.config)
+fs.link_files dir $HOME/.config
 ```
 ---
 
 <h5>fs.link_files</h5>
-Symlinks all files in given folder as dotfiles into `$ELLIPSIS_HOME`.
+Calls `fs.link_file` for all files in a given directory.
+
+The function accepts an optional second parameter to link to another directory
+then `$ELLIPSIS_HOME`.
 
 ``` bash
-# example (Links all files in 'dir' to $HOME)
+# example (Links all files in 'dir' to $ELLIPSIS_HOME, prepended with a dot)
 fs.link_files dir
+
+# example (Links all files in 'dir' to $HOME/.config, prepended with a dot)
+fs.link_files dir $HOME/.config
 ```
 ---
 

--- a/src/fs.bash
+++ b/src/fs.bash
@@ -124,6 +124,19 @@ fs.link_file() {
 # find all files in dir excluding the dir itself, hidden files, README,
 # LICENSE, *.rst, *.md, and *.txt and symlink into ELLIPSIS_HOME.
 fs.link_files() {
+    local src_dir="${1:-.}"
+    local dest_dir="${2:-$ELLIPSIS_HOME}"
+
+    fs.link_rfiles "$src_dir" "$dest_dir" '.'
+}
+
+# find all files in dir excluding the dir itself, hidden files, README,
+# LICENSE, *.rst, *.md, and *.txt and symlink into ELLIPSIS_HOME.
+fs.link_rfiles() {
+    local src_dir="${1:-.}"
+    local dest_dir="${2:-$ELLIPSIS_HOME}"
+    local prefix="$3"
+
     for file in $(find "$1" -maxdepth 1 -name '*' \
                                       ! -name '.*' \
                                       ! -name 'README' \
@@ -133,7 +146,10 @@ fs.link_files() {
                                       ! -name '*.txt' \
                                       ! -name "ellipsis.sh" | sort); do
         if [ ! "$1" = "$file" ]; then
-            fs.link_file "$file"
+            local src="$(path.abs_path "$file")"
+            local name="${src##*/}"
+            local dest="${dest_dir}/${prefix}${name}"
+            fs.link_rfile "$file" "$dest"
         fi
     done
 }

--- a/test/fs.bats
+++ b/test/fs.bats
@@ -109,12 +109,34 @@ teardown() {
     [ ! -e tmp/broken_symlink ]
 }
 
-@test "fs.link_rfile should link a file into HOME" {
+@test "fs.link_rfile should link a regular file into HOME" {
     run fs.link_rfile tmp/file_to_link
     [ $status -eq 0 ]
     [ -f "$(readlink "$ELLIPSIS_HOME/file_to_link")" ]
     [ -f tmp/file_to_link ]
     [[ "$output" == linking* ]] || false
+}
+
+@test "fs.link_rfile should link a regular file to a custom location" {
+    # Setup
+    mkdir tmp/test
+
+    run fs.link_rfile tmp/file_to_link tmp/test/file1
+    [ $status -eq 0 ]
+    [ -f "$(readlink "tmp/test/file1")" ]
+    [ -f tmp/file_to_link ]
+    [[ "$output" == linking* ]] || false
+}
+
+@test "fs.link_rfile should create a backup for existing files" {
+    # Setup
+    touch "$ELLIPSIS_HOME/file_to_link"
+
+    run fs.link_rfile tmp/file_to_link
+    [ $status -eq 0 ]
+    [ -f "$(readlink "$ELLIPSIS_HOME/file_to_link")" ]
+    [ -f tmp/file_to_link ]
+    [ -f "$ELLIPSIS_HOME/file_to_link.bak" ]
 }
 
 @test "fs.link_file should link a file into HOME" {
@@ -125,7 +147,43 @@ teardown() {
     [[ "$output" == linking* ]] || false
 }
 
-@test "fs.link_files should link all the files in folder into HOME" {
+@test "fs.link_rfiles should link all regular files in a folder into HOME" {
+    run fs.link_rfiles tmp
+    [ $status -eq 0 ]
+    [ -f "$(readlink "$ELLIPSIS_HOME/file_to_link")" ]
+    [ -f tmp/file_to_link ]
+    [ -f "$(readlink "$ELLIPSIS_HOME/file_to_backup")" ]
+    [ -f tmp/file_to_backup ]
+    [[ "$output" == linking* ]] || false
+}
+
+@test "fs.link_rfiles should link all regular files in a folder to a custom location" {
+    # Setup
+    mkdir tmp/test
+
+    run fs.link_rfiles tmp tmp/test
+    [ $status -eq 0 ]
+    [ -f "$(readlink "tmp/test/file_to_link")" ]
+    [ -f tmp/file_to_link ]
+    [ -f "$(readlink "tmp/test/file_to_backup")" ]
+    [ -f tmp/file_to_backup ]
+    [[ "$output" == linking* ]] || false
+}
+
+@test "fs.link_rfiles should link all regular files in a folder with a custom prefix" {
+    # Setup
+    mkdir tmp/test
+
+    run fs.link_rfiles tmp tmp/test 'test_'
+    [ $status -eq 0 ]
+    [ -f "$(readlink "tmp/test/test_file_to_link")" ]
+    [ -f tmp/file_to_link ]
+    [ -f "$(readlink "tmp/test/test_file_to_backup")" ]
+    [ -f tmp/file_to_backup ]
+    [[ "$output" == linking* ]] || false
+}
+
+@test "fs.link_files should link all the files in a folder into HOME" {
     run fs.link_files tmp
     [ $status -eq 0 ]
     [ -f "$(readlink "$ELLIPSIS_HOME/.file_to_link")" ]
@@ -134,6 +192,20 @@ teardown() {
     [ -f tmp/file_to_backup ]
     [[ "$output" == linking* ]] || false
 }
+
+@test "fs.link_files should link all the files in a folder to a custom location" {
+    # Setup
+    mkdir tmp/test
+
+    run fs.link_files tmp tmp/test
+    [ $status -eq 0 ]
+    [ -f "$(readlink "tmp/test/.file_to_link")" ]
+    [ -f tmp/file_to_link ]
+    [ -f "$(readlink "tmp/test/.file_to_backup")" ]
+    [ -f tmp/file_to_backup ]
+    [[ "$output" == linking* ]] || false
+}
+
 
 @test "fs.is_ellipsis_symlink should detect symlink pointing back to ELLIPSIS_PATH" {
     run fs.is_ellipsis_symlink $ELLIPSIS_HOME/.test


### PR DESCRIPTION
Adds the `fs.link_rfiles` function to implement #80. Also reimplements
`fs.link_files` by calling `fs.link_rfiles` with an additional prefix
parameter.

`fs.link_files` now also has the option to specify an alternative folder
for linking the files. Default still links to `$ELLIPSIS_HOME`.

Includes additional tests for testing new features + docs.