### PR TITLE
Add relink command

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,7 @@ Usage: ellipsis <command>
     uninstall  uninstall package
     link       link package
     unlink     unlink package
+    relink     relink package
     broken     list any broken symlinks
     clean      rm broken symlinks
     installed  list installed packages

--- a/src/cli.bash
+++ b/src/cli.bash
@@ -28,6 +28,7 @@ Usage: ellipsis <command>
     uninstall  uninstall package
     link       link package
     unlink     unlink package
+    relink     relink package
     broken     list any broken symlinks
     clean      rm broken symlinks
     installed  list installed packages
@@ -125,6 +126,10 @@ cli.run() {
             ;;
         unlink)
             ellipsis.unlink $2
+            ;;
+        relink)
+            ellipsis.unlink $2
+            ellipsis.link $2
             ;;
         links|symlinks)
             ellipsis.links $2


### PR DESCRIPTION
Add's a `relink` command. This is very convenient when working on `ellipsis.sh` files and you need to test the linking/unlinking a few times.

Would have prefered a `-f` or `--force` option to the `link` command. But flags are currently not well supported so this was the simplest alternative.