### PR TITLE
Add manual install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,17 @@ Ellipsis is a package manager for dotfiles.
 Clone and symlink or use handy-dandy installer:
 
 ```bash
+# Manual install
+$ git clone https://github.com/ellipsis/ellipsis .ellipsis
+
+# Using installer
 $ curl ellipsis.sh | sh
 ```
 
 <sup>...no you didn't read that wrong, [the ellipsis.sh website also doubles as the installer][installer]</sup>
 
-You can also specify which packages to install by setting the `PACKAGES` variable, i.e.:
+With the installer you can also specify which packages to install by setting
+the `PACKAGES` variable, i.e.:
 
 ```bash
 $ curl ellipsis.sh | PACKAGES='vim zsh' sh
@@ -39,9 +44,9 @@ $ curl ellipsis.sh | PACKAGES='vim zsh' sh
 Add `~/.ellipsis/bin` to your `$PATH` (or symlink somewhere convenient) and
 start managing your dotfiles in style :)
 
-As of version `1.7.3` you can also use the init system to automatically setup
-you environment. As a bonus it will allow you to use the powerful `pkg.init`
-hook to do the same for your packages.
+As of version `1.7.3` you can also use [the init system][docs-init] to
+automatically setup you environment. As a bonus it will allow you to use the
+powerful `pkg.init` hook to do the same for your packages.
 
 ### Usage
 Ellipsis comes with no dotfiles out of the box. To install packages, use

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,11 +5,15 @@
 Clone and symlink or use handy-dandy installer:
 
 ```bash
+# Manual install
+$ git clone https://github.com/ellipsis/ellipsis .ellipsis
+
+# Using installer
 $ curl -sL ellipsis.sh | sh
 ```
 
-You can also specify which packages to install by setting the `PACKAGES`
-variable, i.e.:
+With the installer you can also specify which packages to install by setting
+the `PACKAGES` variable, i.e.:
 
 ```bash
 $ curl -sL ellipsis.sh | PACKAGES='vim zsh' sh
@@ -18,6 +22,8 @@ $ curl -sL ellipsis.sh | PACKAGES='vim zsh' sh
 Add `~/.ellipsis/bin` to your `$PATH` (or symlink somewhere convenient) and
 start managing your dotfiles in style :)
 
-As of version `1.7.3` you can also use the init system to automatically setup
-your environment. As a bonus it will allow you to use the powerful `pkg.init`
-hook to do the same for your packages.
+As of version `1.7.3` you can also use [the init system][init] to automatically
+setup your environment. As a bonus it will allow you to use the powerful
+`pkg.init` hook to do the same for your packages.
+
+[init]: init.md


### PR DESCRIPTION
Had a few questions about installing ellipsis without the installer (`curl | sh`) because this is not the best thing to do for security. So I added the example to the manual and README.

Also added a quick link to the init docs so people can more easily find the snippet to add to there bash/zsh rc file.