### PR TITLE
Show correct source during `fs.backup`

### DIFF
--- a/src/fs.bash
+++ b/src/fs.bash
@@ -69,7 +69,7 @@ fs.backup() {
 
     # remove broken symlink
     if fs.is_broken_symlink "$original"; then
-        msg.dim "rm ~/$name (broken link to $(readlink "$original"))"
+        msg.dim "rm $(path.relative_to_home "$original") (broken link to $(readlink "$original"))"
         rm "$original"
         return
     fi
@@ -81,7 +81,7 @@ fs.backup() {
 
     # if file exists and is a symlink to ellipsis, remove
     if fs.is_ellipsis_symlink "$original"; then
-        msg.dim "rm ~/$name (linked to $(path.relative_to_packages "$(readlink "$original")"))"
+        msg.dim "rm $(path.relative_to_home "$original") (linked to $(path.relative_to_packages "$(readlink "$original")"))"
         rm "$original"
         return
     fi


### PR DESCRIPTION
When e.g. calling `ellipsis link <pkg>` where `<pkg>` implements a custom `pkg.link` hook that links files into subdirectories rather than directly into `$HOME`, the messages from `fs.backup` informing the user about removing the existing links were wrong.

E.g. the message said it was removing `~/mylink` instead of `~/.config/mylink`.

This change fixes these. (I have tested both broken symlinks as well as working symlinks and got the results I expected; for both files directly in `$HOME` as well as files in subdirectories.)