### PR TITLE
Fix WSL2 detection

### DIFF
--- a/src/os.bash
+++ b/src/os.bash
@@ -3,7 +3,7 @@
 # Platform detection and OS functions.
 
 os.platform() {
-    case "$(uname)" in
+    case "$(uname -rs)" in
         CYGWIN*)
             echo cygwin
             ;;


### PR DESCRIPTION
Adds a more verbose `uname` command to fix detection of WSL2.